### PR TITLE
Get the nice Travis status back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.8.3
   - 1.9
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.com/Shopify/kubeaudit.svg?token=wh19RsdvyDqC62mzTTLb&branch=master)](https://travis-ci.com/Shopify/kubeaudit/)
+[![Build Status](https://api.travis-ci.org/Shopify/kubeaudit.svg?branch=master)](https://travis-ci.com/Shopify/kubeaudit/)
 
 # kubeaudit
 


### PR DESCRIPTION
This addresses #4 by changing the url and dropping support for `go1.8.3`