### PR TITLE
New command to print version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Available Commands:
   np          Audit namespace network policies
   rbac        Audit RBAC things
   sc          Audit container security contexts
+  version     Print the version number of kubeaudit
 
 Flags:
   -a, --allPods             Audit againsts pods in all the phases (default Running Phase)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+
+const Version = "0.1.0"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of kubeaudit",
+	Long:  `This just prints the version of kubeaudit`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.WithFields(log.Fields{
+			"Version": Version,
+		}).Info("Kubeaudit")
+	},
+}


### PR DESCRIPTION
In order to print the kubeaudit's current version, a new command has been added to kubeaudit

```sh
./kubeaudit version
INFO[0000] Kubeaudit                                     Version=0.1.0
```