### PR TITLE
image: Fix confusion between image name and image tag

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -20,7 +20,7 @@ func printResultImg(results []Result) {
 		if result.err > 0 {
 			log.WithFields(log.Fields{
 				"type": result.kubeType,
-				"tag":  result.img}).Error(result.namespace,
+				"tag":  result.img_tag}).Error(result.namespace,
 				"/", result.name)
 
 		}
@@ -56,7 +56,8 @@ func checkImage(container apiv1.Container, image string, result *Result) {
 
 	if contImg == compImg && contTag != compImgTag {
 		result.err = 1
-		result.img = contImg
+		result.img_name = contImg
+		result.img_tag = contTag
 	}
 	return
 }

--- a/cmd/image_test.go
+++ b/cmd/image_test.go
@@ -28,24 +28,28 @@ func TestDeploymentImg(t *testing.T) {
 	}
 
 	for _, result := range results {
-		if result.name == "fakeDeploymentImg1" && result.err != 1 {
+		if result.img_name == "fakeDeploymentImg1" && result.err != 1 {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakeDeploymentImg1.yml")
+		}
+
+		if result.img_name == "fakeDeploymentImg2" && result.img_tag != "1.5" {
+			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: fakeDeploymentImg2.yml")
 		}
 	}
 
 	results = auditImages("fakeContainerImg:1.6", kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 2 {
-		t.Error("Test 3: Failed to identify all bad configurations")
+		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakeDeploymentImg1" && result.err != 1 {
-			t.Error("Test 4: Failed to identify that image tag is missing. Refer: fakeDeploymentImg1.yml")
+		if result.img_name == "fakeDeploymentImg1" && result.err != 1 {
+			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeDeploymentImg1.yml")
 		}
 
-		if result.name == "fakeDeploymentImg2" && result.err != 1 {
-			t.Error("Test 5: Failed to identify wrong image tag. Refer: fakeDeploymentImg2.yml")
+		if result.img_name == "fakeDeploymentImg2" && result.err != 1 {
+			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeDeploymentImg2.yml")
 		}
 	}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -51,12 +51,13 @@ type Result struct {
 	namespace   string
 	name        string
 	capsAdded   []apiv1.Capability
-	img         string
+	img_name    string
 	capsDropped bool
 	kubeType    string
 	dsa         string
 	sa          string
 	token       *bool
+	img_tag     string
 }
 
 type Items interface {


### PR DESCRIPTION
This is a minor patch in order to fix the confusion between image tag and image name in the logs while auditing against some image.