### PR TITLE
Print INFO message for matching image:tag

### DIFF
--- a/cmd/image_test.go
+++ b/cmd/image_test.go
@@ -48,7 +48,7 @@ func TestDeploymentImg(t *testing.T) {
 			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeDeploymentImg1.yml")
 		}
 
-		if result.img_name == "fakeDeploymentImg2" && result.err != 1 {
+		if result.img_name == "fakeDeploymentImg2" && result.err != 2 {
 			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeDeploymentImg2.yml")
 		}
 	}
@@ -68,21 +68,25 @@ func TestStatefulSetImg(t *testing.T) {
 		if result.name == "fakeStatefulSetImg1" && result.err != 1 {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakeStatefulSetImg1.yml")
 		}
+
+		if result.name == "fakeStatefulSetImg2" && result.img_tag != "1.5" {
+			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: fakeStatefulSetImg2.yml")
+		}
 	}
 
 	results = auditImages("fakeContainerImg:1.6", kubeAuditStatefulSets{list: fakeStatefulSets})
 
 	if len(results) != 2 {
-		t.Error("Test 3: Failed to identify all bad configurations")
+		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
 		if result.name == "fakeStatefulSetImg1" && result.err != 1 {
-			t.Error("Test 4: Failed to identify that image tag is missing. Refer: fakeStatefulSetImg1")
+			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeStatefulSetImg1")
 		}
 
-		if result.name == "fakeStatefulSetImg2" && result.err != 1 {
-			t.Error("Test 5: Failed to identify wrong image tag. Refer: fakeStatefulSetImg2")
+		if result.name == "fakeStatefulSetImg2" && result.err != 2 {
+			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeStatefulSetImg2")
 		}
 	}
 
@@ -101,21 +105,25 @@ func TestDaemonSetImg(t *testing.T) {
 		if result.name == "fakeDaemonSetImg1" && result.err != 1 {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakeDaemonSetImg1.yml")
 		}
+
+		if result.name == "fakeDaemonSetImg2" && result.img_tag != "1.5" {
+			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: fakeDaemonSetImg2.yml")
+		}
 	}
 
 	results = auditImages("fakeContainerImg:1.6", kubeAuditDaemonSets{list: fakeDaemonSets})
 
 	if len(results) != 2 {
-		t.Error("Test 3: Failed to identify all bad configurations")
+		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
 		if result.name == "fakeDaemonSetImg1" && result.err != 1 {
-			t.Error("Test 4: Failed to identify that image tag is missing. Refer: fakeDaemonSetImg1")
+			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeDaemonSetImg1")
 		}
 
-		if result.name == "fakeDaemonSetImg2" && result.err != 1 {
-			t.Error("Test 5: Failed to identify wrong image tag. Refer: fakeDaemonSetImg2")
+		if result.name == "fakeDaemonSetImg2" && result.err != 2 {
+			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeDaemonSetImg2")
 		}
 	}
 
@@ -134,21 +142,25 @@ func TestPodImg(t *testing.T) {
 		if result.name == "fakePodImg1" && result.err != 1 {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakePodImg1.yml")
 		}
+
+		if result.name == "fakePodImg2" && result.img_tag != "1.5" {
+			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: akePodImg2.yml")
+		}
 	}
 
 	results = auditImages("fakeContainerImg:1.6", kubeAuditPods{list: fakePods})
 
 	if len(results) != 2 {
-		t.Error("Test 3: Failed to identify all bad configurations")
+		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
 		if result.name == "fakePodImg1" && result.err != 1 {
-			t.Error("Test 4: Failed to identify that image tag is missing. Refer: fakePodImg1")
+			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakePodImg1")
 		}
 
-		if result.name == "fakePodImg2" && result.err != 1 {
-			t.Error("Test 5: Failed to identify wrong image tag. Refer: fakePodImg2")
+		if result.name == "fakePodImg2" && result.err != 2 {
+			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakePodImg2")
 		}
 	}
 
@@ -167,21 +179,25 @@ func TestReplicationControllerImg(t *testing.T) {
 		if result.name == "fakeReplicationControllerImg1" && result.err != 1 {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakeReplicationControllerImg1.yml")
 		}
+
+		if result.name == "fakeReplicationControllerImg2" && result.img_tag != "1.5" {
+			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: fakeReplicationControllerImg2.yml")
+		}
 	}
 
 	results = auditImages("fakeContainerImg:1.6", kubeAuditReplicationControllers{list: fakeReplicationControllers})
 
 	if len(results) != 2 {
-		t.Error("Test 3: Failed to identify all bad configurations")
+		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
 		if result.name == "fakeReplicationControllerImg1" && result.err != 1 {
-			t.Error("Test 4: Failed to identify that image tag is missing. Refer: fakeReplicationControllerImg1")
+			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeReplicationControllerImg1")
 		}
 
-		if result.name == "fakeReplicationControllerImg2" && result.err != 1 {
-			t.Error("Test 5: Failed to identify wrong image tag. Refer: fakeReplicationControllerImg2")
+		if result.name == "fakeReplicationControllerImg2" && result.err != 2 {
+			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeReplicationControllerImg2")
 		}
 	}
 


### PR DESCRIPTION
As per the documentation string:
```
An INFO log is given when a container has a matching image:tag
An ERROR log is generated when a container does not match the image:tag
```
This is not what is happening. Currently, it only prints the `ERROR` log. This pull request updates the `kubectl image` command to also print an `INFO` log when the `image:tag` matches.