### PR TITLE
new feature: audit manifest file from command line args

### DIFF
--- a/cmd/privileged.go
+++ b/cmd/privileged.go
@@ -55,30 +55,37 @@ A FAIL is generated when a container runs in a privileged mode
 Example usage:
 kubeaudit privileged`,
 	Run: func(cmd *cobra.Command, args []string) {
-		kube, err := kubeClient(rootConfig.kubeConfig)
-		if err != nil {
-			log.Error(err)
-		}
-
 		if rootConfig.json {
 			log.SetFormatter(&log.JSONFormatter{})
 		}
 
-		// fetch deployments, statefulsets, daemonsets
-		// and pods which do not belong to another abstraction
-		deployments := getDeployments(kube)
-		statefulSets := getStatefulSets(kube)
-		daemonSets := getDaemonSets(kube)
-		pods := getPods(kube)
-		replicationControllers := getReplicationControllers(kube)
+		if rootConfig.manifest != "" {
+			wg.Add(1)
+			resource := getKubeResource(rootConfig.manifest)
+			auditSecurityContext(resource)
+			wg.Wait()
+		} else {
+			kube, err := kubeClient(rootConfig.kubeConfig)
+			if err != nil {
+				log.Error(err)
+			}
 
-		wg.Add(5)
-		go auditPrivileged(kubeAuditStatefulSets{list: statefulSets})
-		go auditPrivileged(kubeAuditDaemonSets{list: daemonSets})
-		go auditPrivileged(kubeAuditPods{list: pods})
-		go auditPrivileged(kubeAuditReplicationControllers{list: replicationControllers})
-		go auditPrivileged(kubeAuditDeployments{list: deployments})
-		wg.Wait()
+			// fetch deployments, statefulsets, daemonsets
+			// and pods which do not belong to another abstraction
+			deployments := getDeployments(kube)
+			statefulSets := getStatefulSets(kube)
+			daemonSets := getDaemonSets(kube)
+			pods := getPods(kube)
+			replicationControllers := getReplicationControllers(kube)
+
+			wg.Add(5)
+			go auditPrivileged(kubeAuditStatefulSets{list: statefulSets})
+			go auditPrivileged(kubeAuditDaemonSets{list: daemonSets})
+			go auditPrivileged(kubeAuditPods{list: pods})
+			go auditPrivileged(kubeAuditReplicationControllers{list: replicationControllers})
+			go auditPrivileged(kubeAuditDeployments{list: deployments})
+			wg.Wait()
+		}
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ type rootFlags struct {
 	verbose    bool
 	allPods    bool
 	json       bool
+	manifest   string
 }
 
 var RootCmd = &cobra.Command{
@@ -41,4 +42,5 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.verbose, "verbose", "v", false, "Enable debug (verbose) logging")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.json, "json", "j", false, "Enable json logging")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.allPods, "allPods", "a", false, "Audit againsts pods in all the phases (default Running Phase)")
+	RootCmd.PersistentFlags().StringVarP(&rootConfig.manifest, "manifest", "f", "", "yaml configuration to audit")
 }

--- a/cmd/runAsNonRoot.go
+++ b/cmd/runAsNonRoot.go
@@ -57,30 +57,37 @@ A FAIL is generated when a container runs as root
 Example usage:
 kubeaudit runAsNonRoot`,
 	Run: func(cmd *cobra.Command, args []string) {
-		kube, err := kubeClient(rootConfig.kubeConfig)
-		if err != nil {
-			log.Error(err)
-		}
-
 		if rootConfig.json {
 			log.SetFormatter(&log.JSONFormatter{})
 		}
 
-		// fetch deployments, statefulsets, daemonsets
-		// and pods which do not belong to another abstraction
-		deployments := getDeployments(kube)
-		statefulSets := getStatefulSets(kube)
-		daemonSets := getDaemonSets(kube)
-		pods := getPods(kube)
-		replicationControllers := getReplicationControllers(kube)
+		if rootConfig.manifest != "" {
+			wg.Add(1)
+			resource := getKubeResource(rootConfig.manifest)
+			auditSecurityContext(resource)
+			wg.Wait()
+		} else {
+			kube, err := kubeClient(rootConfig.kubeConfig)
+			if err != nil {
+				log.Error(err)
+			}
 
-		wg.Add(5)
-		go auditRunAsNonRoot(kubeAuditStatefulSets{list: statefulSets})
-		go auditRunAsNonRoot(kubeAuditDaemonSets{list: daemonSets})
-		go auditRunAsNonRoot(kubeAuditPods{list: pods})
-		go auditRunAsNonRoot(kubeAuditReplicationControllers{list: replicationControllers})
-		go auditRunAsNonRoot(kubeAuditDeployments{list: deployments})
-		wg.Wait()
+			// fetch deployments, statefulsets, daemonsets
+			// and pods which do not belong to another abstraction
+			deployments := getDeployments(kube)
+			statefulSets := getStatefulSets(kube)
+			daemonSets := getDaemonSets(kube)
+			pods := getPods(kube)
+			replicationControllers := getReplicationControllers(kube)
+
+			wg.Add(5)
+			go auditRunAsNonRoot(kubeAuditStatefulSets{list: statefulSets})
+			go auditRunAsNonRoot(kubeAuditDaemonSets{list: daemonSets})
+			go auditRunAsNonRoot(kubeAuditPods{list: pods})
+			go auditRunAsNonRoot(kubeAuditReplicationControllers{list: replicationControllers})
+			go auditRunAsNonRoot(kubeAuditDeployments{list: deployments})
+			wg.Wait()
+		}
 	},
 }
 

--- a/cmd/securityContext_test.go
+++ b/cmd/securityContext_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/Shopify/kubeaudit/fakeaudit"
 	"testing"
+
+	"github.com/Shopify/kubeaudit/fakeaudit"
 )
 
 func init() {

--- a/fakeaudit/utils.go
+++ b/fakeaudit/utils.go
@@ -1,19 +1,20 @@
 package fakeaudit
 
 import (
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"path/filepath"
 )
 
 var absPath, _ = filepath.Abs("../")
 
-func readConfigFiles(filename string) runtime.Object {
+func ReadConfigFiles(filename string) runtime.Object {
 	buf, err := ioutil.ReadFile(filename)
 
 	if err != nil {
@@ -32,32 +33,32 @@ func readConfigFiles(filename string) runtime.Object {
 }
 
 func getDeployment(filename string) (deployment *v1beta1.Deployment) {
-	obj := readConfigFiles(filename)
+	obj := ReadConfigFiles(filename)
 	deployment = obj.(*v1beta1.Deployment)
 	return
 }
 
 func getStatefulSet(filename string) (statefulSet *v1beta1.StatefulSet) {
-	obj := readConfigFiles(filename)
+	obj := ReadConfigFiles(filename)
 	statefulSet = obj.(*v1beta1.StatefulSet)
 	return
 }
 
 func getDaemonSet(filename string) (daemonSet *extensionsv1beta1.DaemonSet) {
-	obj := readConfigFiles(filename)
+	obj := ReadConfigFiles(filename)
 	daemonSet = obj.(*extensionsv1beta1.DaemonSet)
 	return
 }
 
 func getPod(filename string) (pod *apiv1.Pod) {
-	obj := readConfigFiles(filename)
+	obj := ReadConfigFiles(filename)
 	pod = obj.(*apiv1.Pod)
 	pod.Status.Phase = "Running"
 	return
 }
 
 func getReplicationController(filename string) (rc *apiv1.ReplicationController) {
-	obj := readConfigFiles(filename)
+	obj := ReadConfigFiles(filename)
 	rc = obj.(*apiv1.ReplicationController)
 	return
 }


### PR DESCRIPTION
I started working on the new feature to audit config files passed as a command line argument. Right now it works only for securityContext. It needs to be ported to other features too.

I am not happy about of lot of stuff in this PR mostly regarding code quality. Need lot of interface love.  Sorry I was in hurry could not make code more clear.

It is just a proof of concept that is possible to do so.