### PR TITLE
New feature: audit yaml files with more than 1 resource

### DIFF
--- a/cmd/automountServiceAccountToken.go
+++ b/cmd/automountServiceAccountToken.go
@@ -92,9 +92,15 @@ kubeaudit rbac sat`,
 		}
 
 		if rootConfig.manifest != "" {
-			wg.Add(1)
-			resource := getKubeResource(rootConfig.manifest)
-			auditSecurityContext(resource)
+			resources, err := getKubeResources(rootConfig.manifest)
+			if err != nil {
+				log.Error(err)
+			}
+			count := len(resources)
+			wg.Add(count)
+			for _, resource := range resources {
+				go auditSecurityContext(resource)
+			}
 			wg.Wait()
 		} else {
 			kube, err := kubeClient(rootConfig.kubeConfig)

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -114,9 +114,15 @@ kubeaudit image -i gcr.io/google_containers/echoserver:1.7`,
 		}
 
 		if rootConfig.manifest != "" {
-			wg.Add(1)
-			resource := getKubeResource(rootConfig.manifest)
-			auditSecurityContext(resource)
+			resources, err := getKubeResources(rootConfig.manifest)
+			if err != nil {
+				log.Error(err)
+			}
+			count := len(resources)
+			wg.Add(count)
+			for _, resource := range resources {
+				go auditSecurityContext(resource)
+			}
 			wg.Wait()
 		} else {
 			kube, err := kubeClient(rootConfig.kubeConfig)

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -41,7 +41,7 @@ func kubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
 	}
 	config, err := kubeClientConfig(kubeconfig)
 	if err != nil {
-		panic(err)
+		log.Error(err)
 	}
 	kube, err := kubernetes.NewForConfig(config)
 	printKubernetesVersion(kube)

--- a/cmd/privileged.go
+++ b/cmd/privileged.go
@@ -60,9 +60,15 @@ kubeaudit privileged`,
 		}
 
 		if rootConfig.manifest != "" {
-			wg.Add(1)
-			resource := getKubeResource(rootConfig.manifest)
-			auditSecurityContext(resource)
+			resources, err := getKubeResources(rootConfig.manifest)
+			if err != nil {
+				log.Error(err)
+			}
+			count := len(resources)
+			wg.Add(count)
+			for _, resource := range resources {
+				go auditSecurityContext(resource)
+			}
 			wg.Wait()
 		} else {
 			kube, err := kubeClient(rootConfig.kubeConfig)

--- a/cmd/privileged_test.go
+++ b/cmd/privileged_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/Shopify/kubeaudit/fakeaudit"
 	"testing"
+
+	"github.com/Shopify/kubeaudit/fakeaudit"
 )
 
 func init() {
@@ -24,7 +25,7 @@ func TestDeploymentPrivileged(t *testing.T) {
 	results := auditPrivileged(kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 2 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -44,7 +45,7 @@ func TestStatefulSetPrivileged(t *testing.T) {
 	results := auditPrivileged(kubeAuditStatefulSets{list: fakeStatefulSets})
 
 	if len(results) != 2 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -64,7 +65,7 @@ func TestDaemonSetPrivileged(t *testing.T) {
 	results := auditPrivileged(kubeAuditDaemonSets{list: fakeDaemonSets})
 
 	if len(results) != 2 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -84,7 +85,7 @@ func TestPodPrivileged(t *testing.T) {
 	results := auditPrivileged(kubeAuditPods{list: fakePods})
 
 	if len(results) != 2 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -104,7 +105,7 @@ func TestReplicationControllerPrivileged(t *testing.T) {
 	results := auditPrivileged(kubeAuditReplicationControllers{list: fakeReplicationControllers})
 
 	if len(results) != 2 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {

--- a/cmd/readOnlyRootFilesystem.go
+++ b/cmd/readOnlyRootFilesystem.go
@@ -60,9 +60,15 @@ kubeaudit runAsNonRoot`,
 		}
 
 		if rootConfig.manifest != "" {
-			wg.Add(1)
-			resource := getKubeResource(rootConfig.manifest)
-			auditSecurityContext(resource)
+			resources, err := getKubeResources(rootConfig.manifest)
+			if err != nil {
+				log.Error(err)
+			}
+			count := len(resources)
+			wg.Add(count)
+			for _, resource := range resources {
+				go auditSecurityContext(resource)
+			}
 			wg.Wait()
 		} else {
 			kube, err := kubeClient(rootConfig.kubeConfig)

--- a/cmd/readOnlyRootFilesystem_test.go
+++ b/cmd/readOnlyRootFilesystem_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/Shopify/kubeaudit/fakeaudit"
 	"testing"
+
+	"github.com/Shopify/kubeaudit/fakeaudit"
 )
 
 func init() {
@@ -24,7 +25,7 @@ func TestDeploymentRORF(t *testing.T) {
 	results := auditReadOnlyRootFS(kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -48,7 +49,7 @@ func TestStatefulSetRORF(t *testing.T) {
 	results := auditReadOnlyRootFS(kubeAuditStatefulSets{list: fakeStatefulSets})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -72,7 +73,7 @@ func TestDaemonSetRORF(t *testing.T) {
 	results := auditReadOnlyRootFS(kubeAuditDaemonSets{list: fakeDaemonSets})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -96,7 +97,7 @@ func TestPodRORF(t *testing.T) {
 	results := auditReadOnlyRootFS(kubeAuditPods{list: fakePods})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -120,7 +121,7 @@ func TestReplicationControllerRORF(t *testing.T) {
 	results := auditReadOnlyRootFS(kubeAuditReplicationControllers{list: fakeReplicationControllers})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {

--- a/cmd/runAsNonRoot.go
+++ b/cmd/runAsNonRoot.go
@@ -62,9 +62,15 @@ kubeaudit runAsNonRoot`,
 		}
 
 		if rootConfig.manifest != "" {
-			wg.Add(1)
-			resource := getKubeResource(rootConfig.manifest)
-			auditSecurityContext(resource)
+			resources, err := getKubeResources(rootConfig.manifest)
+			if err != nil {
+				log.Error(err)
+			}
+			count := len(resources)
+			wg.Add(count)
+			for _, resource := range resources {
+				go auditSecurityContext(resource)
+			}
 			wg.Wait()
 		} else {
 			kube, err := kubeClient(rootConfig.kubeConfig)

--- a/cmd/runAsNonRoot_test.go
+++ b/cmd/runAsNonRoot_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/Shopify/kubeaudit/fakeaudit"
 	"testing"
+
+	"github.com/Shopify/kubeaudit/fakeaudit"
 )
 
 func init() {
@@ -24,7 +25,7 @@ func TestDeploymentRANR(t *testing.T) {
 	results := auditRunAsNonRoot(kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -48,7 +49,7 @@ func TestStatefulSetRANR(t *testing.T) {
 	results := auditRunAsNonRoot(kubeAuditStatefulSets{list: fakeStatefulSets})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -72,7 +73,7 @@ func TestDaemonSetRANR(t *testing.T) {
 	results := auditRunAsNonRoot(kubeAuditDaemonSets{list: fakeDaemonSets})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -96,7 +97,7 @@ func TestPodRANR(t *testing.T) {
 	results := auditRunAsNonRoot(kubeAuditPods{list: fakePods})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {
@@ -120,7 +121,7 @@ func TestReplicationControllerRANR(t *testing.T) {
 	results := auditRunAsNonRoot(kubeAuditReplicationControllers{list: fakeReplicationControllers})
 
 	if len(results) != 3 {
-		t.Error("Test 1: Failed to caught all bad configurations")
+		t.Error("Test 1: Failed to catch all bad configurations")
 	}
 
 	for _, result := range results {

--- a/cmd/securityContext_test.go
+++ b/cmd/securityContext_test.go
@@ -25,7 +25,7 @@ func TestDeploymentSC(t *testing.T) {
 	results := auditSecurityContext(kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 4 {
-		t.Error("Test 1: Failed to caught all the bad configurations")
+		t.Error("Test 1: Failed to catch all the bad configurations")
 	}
 
 	for _, result := range results {
@@ -57,7 +57,7 @@ func TestStatefulSetSC(t *testing.T) {
 	results := auditSecurityContext(kubeAuditStatefulSets{list: fakeStatefulSets})
 
 	if len(results) != 4 {
-		t.Error("Test 1: Failed to caught all the bad configurations")
+		t.Error("Test 1: Failed to catch all the bad configurations")
 	}
 
 	for _, result := range results {
@@ -89,7 +89,7 @@ func TestDaemonSetSC(t *testing.T) {
 	results := auditSecurityContext(kubeAuditDaemonSets{list: fakeDaemonSets})
 
 	if len(results) != 4 {
-		t.Error("Test 1: Failed to caught all the bad configurations")
+		t.Error("Test 1: Failed to catch all the bad configurations")
 	}
 
 	for _, result := range results {
@@ -121,7 +121,7 @@ func TestPodSC(t *testing.T) {
 	results := auditSecurityContext(kubeAuditPods{list: fakePods})
 
 	if len(results) != 4 {
-		t.Error("Test 1: Failed to caught all the bad configurations")
+		t.Error("Test 1: Failed to catch all the bad configurations")
 	}
 
 	for _, result := range results {
@@ -153,7 +153,7 @@ func TestReplicationControllerSC(t *testing.T) {
 	results := auditSecurityContext(kubeAuditReplicationControllers{list: fakeReplicationControllers})
 
 	if len(results) != 4 {
-		t.Error("Test 1: Failed to caught all the bad configurations")
+		t.Error("Test 1: Failed to catch all the bad configurations")
 	}
 
 	for _, result := range results {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -262,19 +262,25 @@ func ServiceAccountIter(t interface{}) (result *Result) {
 	}
 }
 
-func getKubeResource(config string) (items Items) {
-	resource := fakeaudit.ReadConfigFiles(config)
-	switch resource := resource.(type) {
-	case *v1beta1.Deployment:
-		items = kubeAuditDeployments{list: convertDeploymentToDeploymentList(*resource)}
-	case *v1beta1.StatefulSet:
-		items = kubeAuditStatefulSets{list: convertStatefulSetToStatefulSetList(*resource)}
-	case *extensionsv1beta1.DaemonSet:
-		items = kubeAuditDaemonSets{list: convertDaemonSetToDaemonSetList(*resource)}
-	case *apiv1.Pod:
-		items = kubeAuditPods{list: convertPodToPodList(*resource)}
-	case *apiv1.ReplicationController:
-		items = kubeAuditReplicationControllers{list: convertReplicationControllerToReplicationList(*resource)}
+func getKubeResources(config string) (items []Items, err error) {
+	resources, read_err := fakeaudit.ReadConfigFile(config)
+	if err != nil {
+		err = read_err
+		return
+	}
+	for _, resource := range resources {
+		switch resource := resource.(type) {
+		case *v1beta1.Deployment:
+			items = append(items, kubeAuditDeployments{list: convertDeploymentToDeploymentList(*resource)})
+		case *v1beta1.StatefulSet:
+			items = append(items, kubeAuditStatefulSets{list: convertStatefulSetToStatefulSetList(*resource)})
+		case *extensionsv1beta1.DaemonSet:
+			items = append(items, kubeAuditDaemonSets{list: convertDaemonSetToDaemonSetList(*resource)})
+		case *apiv1.Pod:
+			items = append(items, kubeAuditPods{list: convertPodToPodList(*resource)})
+		case *apiv1.ReplicationController:
+			items = append(items, kubeAuditReplicationControllers{list: convertReplicationControllerToReplicationList(*resource)})
+		}
 	}
 	return
 }

--- a/fakeaudit/fakeDaemonSets.go
+++ b/fakeaudit/fakeDaemonSets.go
@@ -7,47 +7,31 @@ import (
 var daemonSetPath = filepath.Join(absPath, "fakeaudit", "test", "daemonSets")
 
 func CreateFakeDaemonSetSC(namespace string) {
-	fakeDaemonSetClient := getFakeDaemonSetClient(namespace)
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetSC1.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetSC2.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetSC3.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetSC4.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetSC5.yml")))
+	yamls := []string{"fakeDaemonSetSC1.yml", "fakeDaemonSetSC2.yml", "fakeDaemonSetSC3.yml", "fakeDaemonSetSC4.yml", "fakeDaemonSetSC5.yml"}
+	createHelper(namespace, daemonSetPath, yamls)
 }
 
 func CreateFakeDaemonSetRunAsNonRoot(namespace string) {
-	fakeDaemonSetClient := getFakeDaemonSetClient(namespace)
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetRANR1.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetRANR2.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetRANR3.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetRANR4.yml")))
+	yamls := []string{"fakeDaemonSetRANR1.yml", "fakeDaemonSetRANR2.yml", "fakeDaemonSetRANR2.yml", "fakeDaemonSetRANR3.yml", "fakeDaemonSetRANR4.yml"}
+	createHelper(namespace, daemonSetPath, yamls)
 }
 
 func CreateFakeDaemonSetPrivileged(namespace string) {
-	fakeDaemonSetClient := getFakeDaemonSetClient(namespace)
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetPrivileged1.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetPrivileged2.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetPrivileged3.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetPrivileged4.yml")))
+	yamls := []string{"fakeDaemonSetPrivileged1.yml", "fakeDaemonSetPrivileged2.yml", "fakeDaemonSetPrivileged3.yml", "fakeDaemonSetPrivileged4.yml"}
+	createHelper(namespace, daemonSetPath, yamls)
 }
 
 func CreateFakeDaemonSetReadOnlyRootFilesystem(namespace string) {
-	fakeDaemonSetClient := getFakeDaemonSetClient(namespace)
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetRORF1.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetRORF2.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetRORF3.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetRORF4.yml")))
+	yamls := []string{"fakeDaemonSetRORF1.yml", "fakeDaemonSetRORF2.yml", "fakeDaemonSetRORF3.yml", "fakeDaemonSetRORF4.yml"}
+	createHelper(namespace, daemonSetPath, yamls)
 }
 
 func CreateFakeDaemonSetAutomountServiceAccountToken(namespace string) {
-	fakeDaemonSetClient := getFakeDaemonSetClient(namespace)
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetASAT1.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetASAT2.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetASAT3.yml")))
+	yamls := []string{"fakeDaemonSetASAT1.yml", "fakeDaemonSetASAT2.yml", "fakeDaemonSetASAT3.yml"}
+	createHelper(namespace, daemonSetPath, yamls)
 }
 
 func CreateFakeDaemonSetImg(namespace string) {
-	fakeDaemonSetClient := getFakeDaemonSetClient(namespace)
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetImg1.yml")))
-	fakeDaemonSetClient.Create(getDaemonSet(filepath.Join(daemonSetPath, "fakeDaemonSetImg2.yml")))
+	yamls := []string{"fakeDaemonSetImg1.yml", "fakeDaemonSetImg2.yml"}
+	createHelper(namespace, daemonSetPath, yamls)
 }

--- a/fakeaudit/fakeDeployments.go
+++ b/fakeaudit/fakeDeployments.go
@@ -7,47 +7,31 @@ import (
 var deploymentsPath = filepath.Join(absPath, "fakeaudit", "test", "deployments")
 
 func CreateFakeDeploymentSC(namespace string) {
-	fakeDeploymentClient := getFakeDeploymentClient(namespace)
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentSC1.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentSC2.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentSC3.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentSC4.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentSC5.yml")))
+	yamls := []string{"fakeDeploymentSC1.yml", "fakeDeploymentSC2.yml", "fakeDeploymentSC3.yml", "fakeDeploymentSC4.yml", "fakeDeploymentSC5.yml"}
+	createHelper(namespace, deploymentsPath, yamls)
 }
 
 func CreateFakeDeploymentRunAsNonRoot(namespace string) {
-	fakeDeploymentClient := getFakeDeploymentClient(namespace)
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentRANR1.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentRANR2.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentRANR3.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentRANR4.yml")))
+	yamls := []string{"fakeDeploymentRANR1.yml", "fakeDeploymentRANR2.yml", "fakeDeploymentRANR3.yml", "fakeDeploymentRANR4.yml"}
+	createHelper(namespace, deploymentsPath, yamls)
 }
 
 func CreateFakeDeploymentPrivileged(namespace string) {
-	fakeDeploymentClient := getFakeDeploymentClient(namespace)
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentPrivileged1.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentPrivileged2.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentPrivileged3.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentPrivileged4.yml")))
+	yamls := []string{"fakeDeploymentPrivileged1.yml", "fakeDeploymentPrivileged2.yml", "fakeDeploymentPrivileged3.yml", "fakeDeploymentPrivileged4.yml"}
+	createHelper(namespace, deploymentsPath, yamls)
 }
 
 func CreateFakeDeploymentReadOnlyRootFilesystem(namespace string) {
-	fakeDeploymentClient := getFakeDeploymentClient(namespace)
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentRORF1.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentRORF2.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentRORF3.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentRORF4.yml")))
+	yamls := []string{"fakeDeploymentRORF1.yml", "fakeDeploymentRORF2.yml", "fakeDeploymentRORF3.yml", "fakeDeploymentRORF4.yml"}
+	createHelper(namespace, deploymentsPath, yamls)
 }
 
 func CreateFakeDeploymentAutomountServiceAccountToken(namespace string) {
-	fakeDeploymentClient := getFakeDeploymentClient(namespace)
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentASAT1.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentASAT2.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentASAT3.yml")))
+	yamls := []string{"fakeDeploymentASAT1.yml", "fakeDeploymentASAT2.yml", "fakeDeploymentASAT3.yml"}
+	createHelper(namespace, deploymentsPath, yamls)
 }
 
 func CreateFakeDeploymentImg(namespace string) {
-	fakeDeploymentClient := getFakeDeploymentClient(namespace)
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentImg1.yml")))
-	fakeDeploymentClient.Create(getDeployment(filepath.Join(deploymentsPath, "fakeDeploymentImg2.yml")))
+	yamls := []string{"fakeDeploymentImg1.yml", "fakeDeploymentImg2.yml"}
+	createHelper(namespace, deploymentsPath, yamls)
 }

--- a/fakeaudit/fakePods.go
+++ b/fakeaudit/fakePods.go
@@ -7,47 +7,31 @@ import (
 var podsPath = filepath.Join(absPath, "fakeaudit", "test", "pods")
 
 func CreateFakePodSC(namespace string) {
-	fakePodClient := getFakePodClient(namespace)
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodSC1.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodSC2.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodSC3.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodSC4.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodSC5.yml")))
+	yamls := []string{"fakePodSC2.yml", "fakePodSC1.yml", "fakePodSC3.yml", "fakePodSC4.yml", "fakePodSC5.yml"}
+	createHelper(namespace, podsPath, yamls)
 }
 
 func CreateFakePodRunAsNonRoot(namespace string) {
-	fakePodClient := getFakePodClient(namespace)
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodRANR1.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodRANR2.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodRANR3.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodRANR4.yml")))
+	yamls := []string{"fakePodRANR1.yml", "fakePodRANR2.yml", "fakePodRANR3.yml", "fakePodRANR4.yml"}
+	createHelper(namespace, podsPath, yamls)
 }
 
 func CreateFakePodPrivileged(namespace string) {
-	fakePodClient := getFakePodClient(namespace)
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodPrivileged1.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodPrivileged2.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodPrivileged3.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodPrivileged4.yml")))
+	yamls := []string{"fakePodPrivileged1.yml", "fakePodPrivileged2.yml", "fakePodPrivileged3.yml", "fakePodPrivileged4.yml"}
+	createHelper(namespace, podsPath, yamls)
 }
 
 func CreateFakePodReadOnlyRootFilesystem(namespace string) {
-	fakePodClient := getFakePodClient(namespace)
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodRORF1.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodRORF2.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodRORF3.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodRORF4.yml")))
+	yamls := []string{"fakePodRORF1.yml", "fakePodRORF2.yml", "fakePodRORF3.yml", "fakePodRORF4.yml"}
+	createHelper(namespace, podsPath, yamls)
 }
 
 func CreateFakePodAutomountServiceAccountToken(namespace string) {
-	fakePodClient := getFakePodClient(namespace)
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodASAT1.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodASAT2.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodASAT3.yml")))
+	yamls := []string{"fakePodASAT1.yml", "fakePodASAT2.yml", "fakePodASAT3.yml"}
+	createHelper(namespace, podsPath, yamls)
 }
 
 func CreateFakePodImg(namespace string) {
-	fakePodClient := getFakePodClient(namespace)
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodImg1.yml")))
-	fakePodClient.Create(getPod(filepath.Join(podsPath, "fakePodImg2.yml")))
+	yamls := []string{"fakePodImg1.yml", "fakePodImg2.yml"}
+	createHelper(namespace, podsPath, yamls)
 }

--- a/fakeaudit/fakeReplicationControllers.go
+++ b/fakeaudit/fakeReplicationControllers.go
@@ -7,47 +7,31 @@ import (
 var replicationControllerPath = filepath.Join(absPath, "fakeaudit", "test", "replicationControllers")
 
 func CreateFakeReplicationControllerSC(namespace string) {
-	fakeReplicationControllerClient := getFakeReplicationControllerClient(namespace)
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerSC1.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerSC2.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerSC3.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerSC4.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerSC5.yml")))
+	yamls := []string{"fakeReplicationControllerSC1.yml", "fakeReplicationControllerSC2.yml", "fakeReplicationControllerSC3.yml", "fakeReplicationControllerSC4.yml", "fakeReplicationControllerSC5.yml"}
+	createHelper(namespace, replicationControllerPath, yamls)
 }
 
 func CreateFakeReplicationControllerRunAsNonRoot(namespace string) {
-	fakeReplicationControllerClient := getFakeReplicationControllerClient(namespace)
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerRANR1.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerRANR2.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerRANR3.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerRANR4.yml")))
+	yamls := []string{"fakeReplicationControllerRANR1.yml", "fakeReplicationControllerRANR2.yml", "fakeReplicationControllerRANR2.yml", "fakeReplicationControllerRANR3.yml", "fakeReplicationControllerRANR4.yml"}
+	createHelper(namespace, replicationControllerPath, yamls)
 }
 
 func CreateFakeReplicationControllerPrivileged(namespace string) {
-	fakeReplicationControllerClient := getFakeReplicationControllerClient(namespace)
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerPrivileged1.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerPrivileged2.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerPrivileged3.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerPrivileged4.yml")))
+	yamls := []string{"fakeReplicationControllerPrivileged1.yml", "fakeReplicationControllerPrivileged2.yml", "fakeReplicationControllerPrivileged3.yml", "fakeReplicationControllerPrivileged4.yml"}
+	createHelper(namespace, replicationControllerPath, yamls)
 }
 
 func CreateFakeReplicationControllerReadOnlyRootFilesystem(namespace string) {
-	fakeReplicationControllerClient := getFakeReplicationControllerClient(namespace)
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerRORF1.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerRORF2.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerRORF3.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerRORF4.yml")))
+	yamls := []string{"fakeReplicationControllerRORF1.yml", "fakeReplicationControllerRORF2.yml", "fakeReplicationControllerRORF3.yml", "fakeReplicationControllerRORF4.yml"}
+	createHelper(namespace, replicationControllerPath, yamls)
 }
 
 func CreateFakeReplicationControllerAutomountServiceAccountToken(namespace string) {
-	fakeReplicationControllerClient := getFakeReplicationControllerClient(namespace)
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerASAT1.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerASAT2.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerASAT3.yml")))
+	yamls := []string{"fakeReplicationControllerASAT1.yml", "fakeReplicationControllerASAT2.yml", "fakeReplicationControllerASAT3.yml"}
+	createHelper(namespace, replicationControllerPath, yamls)
 }
 
 func CreateFakeReplicationControllerImg(namespace string) {
-	fakeReplicationControllerClient := getFakeReplicationControllerClient(namespace)
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerImg1.yml")))
-	fakeReplicationControllerClient.Create(getReplicationController(filepath.Join(replicationControllerPath, "fakeReplicationControllerImg2.yml")))
+	yamls := []string{"fakeReplicationControllerImg1.yml", "fakeReplicationControllerImg2.yml"}
+	createHelper(namespace, replicationControllerPath, yamls)
 }

--- a/fakeaudit/fakeStatefulSets.go
+++ b/fakeaudit/fakeStatefulSets.go
@@ -7,47 +7,31 @@ import (
 var statefulSetPath = filepath.Join(absPath, "fakeaudit", "test", "statefulSets")
 
 func CreateFakeStatefulSetSC(namespace string) {
-	fakeStatefulSetClient := getFakeStatefulSetClient(namespace)
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetSC1.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetSC2.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetSC3.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetSC4.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetSC5.yml")))
+	yamls := []string{"fakeStatefulSetSC2.yml", "fakeStatefulSetSC1.yml", "fakeStatefulSetSC3.yml", "fakeStatefulSetSC4.yml", "fakeStatefulSetSC5.yml"}
+	createHelper(namespace, statefulSetPath, yamls)
 }
 
 func CreateFakeStatefulSetRunAsNonRoot(namespace string) {
-	fakeStatefulSetClient := getFakeStatefulSetClient(namespace)
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetRANR1.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetRANR2.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetRANR3.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetRANR4.yml")))
+	yamls := []string{"fakeStatefulSetRANR1.yml", "fakeStatefulSetRANR2.yml", "fakeStatefulSetRANR3.yml", "fakeStatefulSetRANR4.yml"}
+	createHelper(namespace, statefulSetPath, yamls)
 }
 
 func CreateFakeStatefulSetPrivileged(namespace string) {
-	fakeStatefulSetClient := getFakeStatefulSetClient(namespace)
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetPrivileged1.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetPrivileged2.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetPrivileged3.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetPrivileged4.yml")))
+	yamls := []string{"fakeStatefulSetPrivileged1.yml", "fakeStatefulSetPrivileged2.yml", "fakeStatefulSetPrivileged3.yml", "fakeStatefulSetPrivileged4.yml"}
+	createHelper(namespace, statefulSetPath, yamls)
 }
 
 func CreateFakeStatefulSetReadOnlyRootFilesystem(namespace string) {
-	fakeStatefulSetClient := getFakeStatefulSetClient(namespace)
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetRORF1.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetRORF2.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetRORF3.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetRORF4.yml")))
+	yamls := []string{"fakeStatefulSetRORF1.yml", "fakeStatefulSetRORF2.yml", "fakeStatefulSetRORF3.yml", "fakeStatefulSetRORF4.yml"}
+	createHelper(namespace, statefulSetPath, yamls)
 }
 
 func CreateFakeStatefulSetAutomountServiceAccountToken(namespace string) {
-	fakeStatefulSetClient := getFakeStatefulSetClient(namespace)
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetASAT1.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetASAT2.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetASAT3.yml")))
+	yamls := []string{"fakeStatefulSetASAT1.yml", "fakeStatefulSetASAT2.yml", "fakeStatefulSetASAT3.yml"}
+	createHelper(namespace, statefulSetPath, yamls)
 }
 
 func CreateFakeStatefulSetImg(namespace string) {
-	fakeStatefulSetClient := getFakeStatefulSetClient(namespace)
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetImg1.yml")))
-	fakeStatefulSetClient.Create(getStatefulSet(filepath.Join(statefulSetPath, "fakeStatefulSetImg2.yml")))
+	yamls := []string{"fakeStatefulSetImg1.yml", "fakeStatefulSetImg2.yml"}
+	createHelper(namespace, statefulSetPath, yamls)
 }


### PR DESCRIPTION
#15 Allowed us to audit maifests, unfortunately it only allowed for one resource to be present in the `manifest.yaml`

In this PR the functionality to audit manifest files that contain more than one resource is introduced.