### PR TITLE
Refactor image

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,7 @@
+package cmd
+
+const (
+	KubeAuditInfo = iota
+	ErrorImageTagMissing
+	ErrorImageTagIncorrect
+)

--- a/cmd/image_test.go
+++ b/cmd/image_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/Shopify/kubeaudit/fakeaudit"
 	"testing"
+
+	"github.com/Shopify/kubeaudit/fakeaudit"
 )
 
 func init() {
@@ -21,34 +22,38 @@ func init() {
 func TestDeploymentImg(t *testing.T) {
 	fakeDeployments := fakeaudit.GetDeployments("fakeDeploymentImg")
 	wg.Add(2)
-	results := auditImages("fakeContainerImg:1.5", kubeAuditDeployments{list: fakeDeployments})
+	image := imgFlags{img: "fakeContainerImg:1.5"}
+	image.splitImageString()
+	results := auditImages(image, kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 1 {
 		t.Error("Test 1: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.img_name == "fakeDeploymentImg1" && result.err != 1 {
+		if result.imgName == "fakeDeploymentImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakeDeploymentImg1.yml")
 		}
 
-		if result.img_name == "fakeDeploymentImg2" && result.img_tag != "1.5" {
+		if result.imgName == "fakeDeploymentImg2" && result.imgTag != "1.5" {
 			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: fakeDeploymentImg2.yml")
 		}
 	}
 
-	results = auditImages("fakeContainerImg:1.6", kubeAuditDeployments{list: fakeDeployments})
+	image = imgFlags{img: "fakeContainerImg:1.6"}
+	image.splitImageString()
+	results = auditImages(image, kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 2 {
 		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.img_name == "fakeDeploymentImg1" && result.err != 1 {
+		if result.imgName == "fakeDeploymentImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeDeploymentImg1.yml")
 		}
 
-		if result.img_name == "fakeDeploymentImg2" && result.err != 2 {
+		if result.imgName == "fakeDeploymentImg2" && result.err != ErrorImageTagIncorrect {
 			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeDeploymentImg2.yml")
 		}
 	}
@@ -58,34 +63,38 @@ func TestDeploymentImg(t *testing.T) {
 func TestStatefulSetImg(t *testing.T) {
 	fakeStatefulSets := fakeaudit.GetStatefulSets("fakeStatefulSetImg")
 	wg.Add(2)
-	results := auditImages("fakeContainerImg:1.5", kubeAuditStatefulSets{list: fakeStatefulSets})
+	image := imgFlags{img: "fakeContainerImg:1.5"}
+	image.splitImageString()
+	results := auditImages(image, kubeAuditStatefulSets{list: fakeStatefulSets})
 
 	if len(results) != 1 {
 		t.Error("Test 1: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakeStatefulSetImg1" && result.err != 1 {
+		if result.name == "fakeStatefulSetImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakeStatefulSetImg1.yml")
 		}
 
-		if result.name == "fakeStatefulSetImg2" && result.img_tag != "1.5" {
+		if result.name == "fakeStatefulSetImg2" && result.imgTag != "1.5" {
 			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: fakeStatefulSetImg2.yml")
 		}
 	}
 
-	results = auditImages("fakeContainerImg:1.6", kubeAuditStatefulSets{list: fakeStatefulSets})
+	image = imgFlags{img: "fakeContainerImg:1.6"}
+	image.splitImageString()
+	results = auditImages(image, kubeAuditStatefulSets{list: fakeStatefulSets})
 
 	if len(results) != 2 {
 		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakeStatefulSetImg1" && result.err != 1 {
+		if result.name == "fakeStatefulSetImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeStatefulSetImg1")
 		}
 
-		if result.name == "fakeStatefulSetImg2" && result.err != 2 {
+		if result.name == "fakeStatefulSetImg2" && result.err != ErrorImageTagIncorrect {
 			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeStatefulSetImg2")
 		}
 	}
@@ -95,34 +104,38 @@ func TestStatefulSetImg(t *testing.T) {
 func TestDaemonSetImg(t *testing.T) {
 	fakeDaemonSets := fakeaudit.GetDaemonSets("fakeDaemonSetImg")
 	wg.Add(2)
-	results := auditImages("fakeContainerImg:1.5", kubeAuditDaemonSets{list: fakeDaemonSets})
+	image := imgFlags{img: "fakeContainerImg:1.5"}
+	image.splitImageString()
+	results := auditImages(image, kubeAuditDaemonSets{list: fakeDaemonSets})
 
 	if len(results) != 1 {
 		t.Error("Test 1: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakeDaemonSetImg1" && result.err != 1 {
+		if result.name == "fakeDaemonSetImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakeDaemonSetImg1.yml")
 		}
 
-		if result.name == "fakeDaemonSetImg2" && result.img_tag != "1.5" {
+		if result.name == "fakeDaemonSetImg2" && result.imgTag != "1.5" {
 			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: fakeDaemonSetImg2.yml")
 		}
 	}
 
-	results = auditImages("fakeContainerImg:1.6", kubeAuditDaemonSets{list: fakeDaemonSets})
+	image = imgFlags{img: "fakeContainerImg:1.6"}
+	image.splitImageString()
+	results = auditImages(image, kubeAuditDaemonSets{list: fakeDaemonSets})
 
 	if len(results) != 2 {
 		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakeDaemonSetImg1" && result.err != 1 {
+		if result.name == "fakeDaemonSetImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeDaemonSetImg1")
 		}
 
-		if result.name == "fakeDaemonSetImg2" && result.err != 2 {
+		if result.name == "fakeDaemonSetImg2" && result.err != ErrorImageTagIncorrect {
 			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeDaemonSetImg2")
 		}
 	}
@@ -132,34 +145,38 @@ func TestDaemonSetImg(t *testing.T) {
 func TestPodImg(t *testing.T) {
 	fakePods := fakeaudit.GetPods("fakePodImg")
 	wg.Add(2)
-	results := auditImages("fakeContainerImg:1.5", kubeAuditPods{list: fakePods})
+	image := imgFlags{img: "fakeContainerImg:1.5"}
+	image.splitImageString()
+	results := auditImages(image, kubeAuditPods{list: fakePods})
 
 	if len(results) != 1 {
 		t.Error("Test 1: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakePodImg1" && result.err != 1 {
+		if result.name == "fakePodImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakePodImg1.yml")
 		}
 
-		if result.name == "fakePodImg2" && result.img_tag != "1.5" {
+		if result.name == "fakePodImg2" && result.imgTag != "1.5" {
 			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: akePodImg2.yml")
 		}
 	}
 
-	results = auditImages("fakeContainerImg:1.6", kubeAuditPods{list: fakePods})
+	image = imgFlags{img: "fakeContainerImg:1.6"}
+	image.splitImageString()
+	results = auditImages(image, kubeAuditPods{list: fakePods})
 
 	if len(results) != 2 {
 		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakePodImg1" && result.err != 1 {
+		if result.name == "fakePodImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakePodImg1")
 		}
 
-		if result.name == "fakePodImg2" && result.err != 2 {
+		if result.name == "fakePodImg2" && result.err != ErrorImageTagIncorrect {
 			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakePodImg2")
 		}
 	}
@@ -169,34 +186,38 @@ func TestPodImg(t *testing.T) {
 func TestReplicationControllerImg(t *testing.T) {
 	fakeReplicationControllers := fakeaudit.GetReplicationControllers("fakeReplicationControllerImg")
 	wg.Add(2)
-	results := auditImages("fakeContainerImg:1.5", kubeAuditReplicationControllers{list: fakeReplicationControllers})
+	image := imgFlags{img: "fakeContainerImg:1.5"}
+	image.splitImageString()
+	results := auditImages(image, kubeAuditReplicationControllers{list: fakeReplicationControllers})
 
 	if len(results) != 1 {
 		t.Error("Test 1: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakeReplicationControllerImg1" && result.err != 1 {
+		if result.name == "fakeReplicationControllerImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 2: Failed to identify that image tag is missing. Refer: fakeReplicationControllerImg1.yml")
 		}
 
-		if result.name == "fakeReplicationControllerImg2" && result.img_tag != "1.5" {
+		if result.name == "fakeReplicationControllerImg2" && result.imgTag != "1.5" {
 			t.Error("Test 3: Failed to identify the correct image tag which is present. Refer: fakeReplicationControllerImg2.yml")
 		}
 	}
 
-	results = auditImages("fakeContainerImg:1.6", kubeAuditReplicationControllers{list: fakeReplicationControllers})
+	image = imgFlags{img: "fakeContainerImg:1.6"}
+	image.splitImageString()
+	results = auditImages(image, kubeAuditReplicationControllers{list: fakeReplicationControllers})
 
 	if len(results) != 2 {
 		t.Error("Test 4: Failed to identify all bad configurations")
 	}
 
 	for _, result := range results {
-		if result.name == "fakeReplicationControllerImg1" && result.err != 1 {
+		if result.name == "fakeReplicationControllerImg1" && result.err != ErrorImageTagMissing {
 			t.Error("Test 5: Failed to identify that image tag is missing. Refer: fakeReplicationControllerImg1")
 		}
 
-		if result.name == "fakeReplicationControllerImg2" && result.err != 2 {
+		if result.name == "fakeReplicationControllerImg2" && result.err != ErrorImageTagIncorrect {
 			t.Error("Test 6: Failed to identify wrong image tag. Refer: fakeReplicationControllerImg2")
 		}
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -86,13 +86,13 @@ type Result struct {
 	namespace   string
 	name        string
 	capsAdded   []apiv1.Capability
-	img_name    string
+	imgName     string
 	capsDropped bool
 	kubeType    string
 	dsa         string
 	sa          string
 	token       *bool
-	img_tag     string
+	imgTag      string
 }
 
 type Items interface {


### PR DESCRIPTION
This is the first step towards error handling. Which lead me into a bit of a refactoring trip field trip.
Anyways, this enables us to easily integrate the functionality that @marc-barry wants to introduce with https://github.com/Shopify/kubeaudit/pull/20 but in a nicer way. I will update the PR once this one is merged.

This removes some splitting code with wasn't nice and `os.Exit(1)` from a function where it's way too late to do an `os.Exit` for a cmd line param check.

- [x] fix the commit message before merge to master
- [ ] squash commits