### PR TITLE
 types: Create internal types instead of using kubernetes types

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -5,7 +5,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	apiv1 "k8s.io/api/core/v1"
 )
 
 var imgConfig imgFlags
@@ -54,7 +53,7 @@ func printResultImg(results []Result) {
 	}
 }
 
-func checkImage(container apiv1.Container, image imgFlags, result *Result) {
+func checkImage(container Container, image imgFlags, result *Result) {
 	image.splitImageString()
 	contImage := imgFlags{img: container.Image}
 	contImage.splitImageString()

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -5,11 +5,8 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networking "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // auth for GKE clusters
@@ -48,54 +45,54 @@ func kubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
 	return kube, err
 }
 
-func getNamespaces(clientset *kubernetes.Clientset) *apiv1.NamespaceList {
+func getNamespaces(clientset *kubernetes.Clientset) *NamespaceList {
 	namespaceClient := clientset.Namespaces()
-	namespaces, err := namespaceClient.List(metav1.ListOptions{})
+	namespaces, err := namespaceClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
 	}
 	return namespaces
 }
 
-func getDeployments(clientset *kubernetes.Clientset) *appsv1beta1.DeploymentList {
+func getDeployments(clientset *kubernetes.Clientset) *DeploymentList {
 	deploymentClient := clientset.AppsV1beta1().Deployments(apiv1.NamespaceAll)
-	deployments, err := deploymentClient.List(metav1.ListOptions{})
+	deployments, err := deploymentClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
 	}
 	return deployments
 }
 
-func getStatefulSets(clientset *kubernetes.Clientset) *appsv1beta1.StatefulSetList {
+func getStatefulSets(clientset *kubernetes.Clientset) *StatefulSetList {
 	statefulSetClient := clientset.AppsV1beta1().StatefulSets(apiv1.NamespaceAll)
-	statefulSets, err := statefulSetClient.List(metav1.ListOptions{})
+	statefulSets, err := statefulSetClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
 	}
 	return statefulSets
 }
 
-func getDaemonSets(clientset *kubernetes.Clientset) *extensionsv1beta1.DaemonSetList {
+func getDaemonSets(clientset *kubernetes.Clientset) *DaemonSetList {
 	daemonSetClient := clientset.ExtensionsV1beta1().DaemonSets(apiv1.NamespaceAll)
-	daemonSets, err := daemonSetClient.List(metav1.ListOptions{})
+	daemonSets, err := daemonSetClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
 	}
 	return daemonSets
 }
 
-func getPods(clientset *kubernetes.Clientset) *apiv1.PodList {
+func getPods(clientset *kubernetes.Clientset) *PodList {
 	podClient := clientset.Pods(apiv1.NamespaceAll)
-	pods, err := podClient.List(metav1.ListOptions{})
+	pods, err := podClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
 	}
 	return pods
 }
 
-func getReplicationControllers(clientset *kubernetes.Clientset) *apiv1.ReplicationControllerList {
+func getReplicationControllers(clientset *kubernetes.Clientset) *ReplicationControllerList {
 	replicationControllerClient := clientset.ReplicationControllers(apiv1.NamespaceAll)
-	replicationControllers, err := replicationControllerClient.List(metav1.ListOptions{})
+	replicationControllers, err := replicationControllerClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
 	}
@@ -104,7 +101,7 @@ func getReplicationControllers(clientset *kubernetes.Clientset) *apiv1.Replicati
 
 func getNetworkPolicies(clientset *kubernetes.Clientset) *networking.NetworkPolicyList {
 	netPolClient := clientset.NetworkPolicies(apiv1.NamespaceAll)
-	netPols, err := netPolClient.List(metav1.ListOptions{})
+	netPols, err := netPolClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
 	}

--- a/cmd/networkPolicies.go
+++ b/cmd/networkPolicies.go
@@ -3,11 +3,10 @@ package cmd
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	networking "k8s.io/api/networking/v1"
 )
 
-func checkNamespaceNetworkPolicies(netPols *networking.NetworkPolicyList) {
-	badNetPols := []networking.NetworkPolicy{}
+func checkNamespaceNetworkPolicies(netPols *NetworkPolicyList) {
+	badNetPols := []NetworkPolicy{}
 
 	for _, netPol := range netPols.Items {
 		for _, ingress := range netPol.Spec.Ingress {

--- a/cmd/privileged.go
+++ b/cmd/privileged.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	apiv1 "k8s.io/api/core/v1"
 )
 
 func printResultPrivileged(results []Result) {
@@ -14,7 +13,7 @@ func printResultPrivileged(results []Result) {
 	}
 }
 
-func checkPrivileged(container apiv1.Container, result *Result) {
+func checkPrivileged(container Container, result *Result) {
 	if container.SecurityContext != nil {
 		if container.SecurityContext.Privileged != nil && *container.SecurityContext.Privileged {
 			result.err = 1

--- a/cmd/readOnlyRootFilesystem.go
+++ b/cmd/readOnlyRootFilesystem.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	apiv1 "k8s.io/api/core/v1"
 )
 
 func printResultRFS(results []Result) {
@@ -31,7 +30,7 @@ func printResultRFS(results []Result) {
 	}
 }
 
-func checkReadOnlyRootFS(container apiv1.Container, result *Result) {
+func checkReadOnlyRootFS(container Container, result *Result) {
 	if container.SecurityContext == nil {
 		result.err = ErrorSecurityContextNIL
 		return

--- a/cmd/runAsNonRoot.go
+++ b/cmd/runAsNonRoot.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	apiv1 "k8s.io/api/core/v1"
 )
 
 func printResultNR(results []Result) {
@@ -31,7 +30,7 @@ func printResultNR(results []Result) {
 	}
 }
 
-func checkRunAsNonRoot(container apiv1.Container, result *Result) {
+func checkRunAsNonRoot(container Container, result *Result) {
 	if container.SecurityContext == nil {
 		result.err = ErrorSecurityContextNIL
 		return

--- a/cmd/securityContext.go
+++ b/cmd/securityContext.go
@@ -5,10 +5,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	apiv1 "k8s.io/api/core/v1"
 )
 
-func checkSecurityContext(container apiv1.Container, result *Result) {
+func checkSecurityContext(container Container, result *Result) {
 	if container.SecurityContext == nil {
 		result.err = ErrorSecurityContextNIL
 		return

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	v1beta1 "k8s.io/api/apps/v1beta1"
+	apiv1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Pod = apiv1.Pod
+type ReplicationController = apiv1.ReplicationController
+type DaemonSet = extensionsv1beta1.DaemonSet
+type Deployment = v1beta1.Deployment
+type StatefulSet = v1beta1.StatefulSet
+type NetworkPolicy = networking.NetworkPolicy
+
+type PodList = apiv1.PodList
+type ReplicationControllerList = apiv1.ReplicationControllerList
+type DaemonSetList = extensionsv1beta1.DaemonSetList
+type DeploymentList = v1beta1.DeploymentList
+type StatefulSetList = v1beta1.StatefulSetList
+type NamespaceList = apiv1.NamespaceList
+type NetworkPolicyList = networking.NetworkPolicyList
+
+type Capability = apiv1.Capability
+type Container = apiv1.Container
+type ListOptions = metav1.ListOptions

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -6,9 +6,6 @@ import (
 
 	fakeaudit "github.com/Shopify/kubeaudit/fakeaudit"
 	log "github.com/sirupsen/logrus"
-	v1beta1 "k8s.io/api/apps/v1beta1"
-	apiv1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 )
 
 var wg sync.WaitGroup
@@ -21,73 +18,73 @@ func debugPrint() {
 	}
 }
 
-func convertDeploymentToDeploymentList(deployment v1beta1.Deployment) (deploymentList *v1beta1.DeploymentList) {
-	deploymentList = &v1beta1.DeploymentList{
-		Items: []v1beta1.Deployment{deployment},
+func convertDeploymentToDeploymentList(deployment Deployment) (deploymentList *DeploymentList) {
+	deploymentList = &DeploymentList{
+		Items: []Deployment{deployment},
 	}
 	return
 
 }
 
-func convertDaemonSetToDaemonSetList(daemonSet extensionsv1beta1.DaemonSet) (daemonSetList *extensionsv1beta1.DaemonSetList) {
-	daemonSetList = &extensionsv1beta1.DaemonSetList{
-		Items: []extensionsv1beta1.DaemonSet{daemonSet},
+func convertDaemonSetToDaemonSetList(daemonSet DaemonSet) (daemonSetList *DaemonSetList) {
+	daemonSetList = &DaemonSetList{
+		Items: []DaemonSet{daemonSet},
 	}
 	return
 
 }
 
-func convertPodToPodList(pod apiv1.Pod) (podList *apiv1.PodList) {
-	podList = &apiv1.PodList{
-		Items: []apiv1.Pod{pod},
+func convertPodToPodList(pod Pod) (podList *PodList) {
+	podList = &PodList{
+		Items: []Pod{pod},
 	}
 	return
 
 }
 
-func convertStatefulSetToStatefulSetList(statefulSet v1beta1.StatefulSet) (statefulSetList *v1beta1.StatefulSetList) {
-	statefulSetList = &v1beta1.StatefulSetList{
-		Items: []v1beta1.StatefulSet{statefulSet},
+func convertStatefulSetToStatefulSetList(statefulSet StatefulSet) (statefulSetList *StatefulSetList) {
+	statefulSetList = &StatefulSetList{
+		Items: []StatefulSet{statefulSet},
 	}
 	return
 
 }
 
-func convertReplicationControllerToReplicationList(replicationController apiv1.ReplicationController) (replicationControllerList *apiv1.ReplicationControllerList) {
-	replicationControllerList = &apiv1.ReplicationControllerList{
-		Items: []apiv1.ReplicationController{replicationController},
+func convertReplicationControllerToReplicationList(replicationController ReplicationController) (replicationControllerList *ReplicationControllerList) {
+	replicationControllerList = &ReplicationControllerList{
+		Items: []ReplicationController{replicationController},
 	}
 	return
 
 }
 
 type kubeAuditDeployments struct {
-	list *v1beta1.DeploymentList
+	list *DeploymentList
 }
 
 type kubeAuditStatefulSets struct {
-	list *v1beta1.StatefulSetList
+	list *StatefulSetList
 }
 
 type kubeAuditDaemonSets struct {
-	list *extensionsv1beta1.DaemonSetList
+	list *DaemonSetList
 }
 
 type kubeAuditPods struct {
-	list *apiv1.PodList
+	list *PodList
 }
 
 type kubeAuditReplicationControllers struct {
-	list *apiv1.ReplicationControllerList
+	list *ReplicationControllerList
 }
 
 type Result struct {
 	err         int
 	namespace   string
 	name        string
-	capsAdded   []apiv1.Capability
+	capsAdded   []Capability
 	imgName     string
-	capsDropped []apiv1.Capability
+	capsDropped []Capability
 	kubeType    string
 	dsa         string
 	sa          string
@@ -147,9 +144,9 @@ func (replicationControllers kubeAuditReplicationControllers) Iter() (it []inter
 	return
 }
 
-func containerIter(t interface{}) (containers []apiv1.Container, result *Result) {
+func containerIter(t interface{}) (containers []Container, result *Result) {
 	switch kubeType := t.(type) {
-	case v1beta1.Deployment:
+	case Deployment:
 		containers = kubeType.Spec.Template.Spec.Containers
 		result = &Result{
 			name:      kubeType.Name,
@@ -158,7 +155,7 @@ func containerIter(t interface{}) (containers []apiv1.Container, result *Result)
 		}
 		return
 
-	case v1beta1.StatefulSet:
+	case StatefulSet:
 		containers = kubeType.Spec.Template.Spec.Containers
 		result = &Result{
 			name:      kubeType.Name,
@@ -167,7 +164,7 @@ func containerIter(t interface{}) (containers []apiv1.Container, result *Result)
 		}
 		return
 
-	case extensionsv1beta1.DaemonSet:
+	case DaemonSet:
 		containers = kubeType.Spec.Template.Spec.Containers
 		result = &Result{
 			name:      kubeType.Name,
@@ -176,7 +173,7 @@ func containerIter(t interface{}) (containers []apiv1.Container, result *Result)
 		}
 		return
 
-	case apiv1.Pod:
+	case Pod:
 		containers = kubeType.Spec.Containers
 		result = &Result{
 			name:      kubeType.Name,
@@ -185,7 +182,7 @@ func containerIter(t interface{}) (containers []apiv1.Container, result *Result)
 		}
 		return
 
-	case apiv1.ReplicationController:
+	case ReplicationController:
 		containers = kubeType.Spec.Template.Spec.Containers
 		result = &Result{
 			name:      kubeType.Name,
@@ -201,7 +198,7 @@ func containerIter(t interface{}) (containers []apiv1.Container, result *Result)
 
 func ServiceAccountIter(t interface{}) (result *Result) {
 	switch kubeType := t.(type) {
-	case v1beta1.Deployment:
+	case Deployment:
 		result = &Result{
 			name:      kubeType.Name,
 			namespace: kubeType.Namespace,
@@ -212,7 +209,7 @@ func ServiceAccountIter(t interface{}) (result *Result) {
 		}
 		return
 
-	case v1beta1.StatefulSet:
+	case StatefulSet:
 		result = &Result{
 			name:      kubeType.Name,
 			namespace: kubeType.Namespace,
@@ -223,7 +220,7 @@ func ServiceAccountIter(t interface{}) (result *Result) {
 		}
 		return
 
-	case extensionsv1beta1.DaemonSet:
+	case DaemonSet:
 		result = &Result{
 			name:      kubeType.Name,
 			namespace: kubeType.Namespace,
@@ -234,7 +231,7 @@ func ServiceAccountIter(t interface{}) (result *Result) {
 		}
 		return
 
-	case apiv1.Pod:
+	case Pod:
 		result = &Result{
 			name:      kubeType.Name,
 			namespace: kubeType.Namespace,
@@ -245,7 +242,7 @@ func ServiceAccountIter(t interface{}) (result *Result) {
 		}
 		return
 
-	case apiv1.ReplicationController:
+	case ReplicationController:
 		result = &Result{
 			name:      kubeType.Name,
 			namespace: kubeType.Namespace,
@@ -270,15 +267,15 @@ func getKubeResources(config string) (items []Items, err error) {
 	}
 	for _, resource := range resources {
 		switch resource := resource.(type) {
-		case *v1beta1.Deployment:
+		case *Deployment:
 			items = append(items, kubeAuditDeployments{list: convertDeploymentToDeploymentList(*resource)})
-		case *v1beta1.StatefulSet:
+		case *StatefulSet:
 			items = append(items, kubeAuditStatefulSets{list: convertStatefulSetToStatefulSetList(*resource)})
-		case *extensionsv1beta1.DaemonSet:
+		case *DaemonSet:
 			items = append(items, kubeAuditDaemonSets{list: convertDaemonSetToDaemonSetList(*resource)})
-		case *apiv1.Pod:
+		case *Pod:
 			items = append(items, kubeAuditPods{list: convertPodToPodList(*resource)})
-		case *apiv1.ReplicationController:
+		case *ReplicationController:
 			items = append(items, kubeAuditReplicationControllers{list: convertReplicationControllerToReplicationList(*resource)})
 		}
 	}


### PR DESCRIPTION
Introduce internal types so that we can have better level of abstraction and it would be easier to changes those types when some internal kubernetes type changes. For example deployment is moving from v1 to v2.

PS: This is only possible because go 1.9 supports type aliasing