### PR TITLE
Only show version info during version command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,3 @@ go:
 script:
   - make setup
   - make test
-  - make check_version

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -41,7 +41,6 @@ func kubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
 		log.Error(err)
 	}
 	kube, err := kubernetes.NewForConfig(config)
-	printKubernetesVersion(kube)
 	return kube, err
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,5 +26,17 @@ var versionCmd = &cobra.Command{
 		log.WithFields(log.Fields{
 			"Version": ver,
 		}).Info("Kubeaudit")
+
+		kubeconfig := rootConfig.kubeConfig
+		if rootConfig.localMode {
+			kubeconfig = os.Getenv("HOME") + "/.kube/config"
+		}
+
+		kube, err := kubeClient(kubeconfig)
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+		printKubernetesVersion(kube)
 	},
 }


### PR DESCRIPTION
Closes #43

Only shows server/client info during `version` command instead of when using `-l` flag.

