### PR TITLE
Refactor, clear up WaitGroup usage

### DIFF
--- a/cmd/automountServiceAccountToken_test.go
+++ b/cmd/automountServiceAccountToken_test.go
@@ -13,7 +13,6 @@ func init() {
 
 func TestReplicationControllerASAT(t *testing.T) {
 	fakeReplicationControllers := fakeaudit.GetReplicationControllers("fakeReplicationControllerASAT")
-	wg.Add(1)
 	results := auditAutomountServiceAccountToken(kubeAuditReplicationControllers{list: fakeReplicationControllers})
 
 	if len(results) != 2 {

--- a/cmd/image_test.go
+++ b/cmd/image_test.go
@@ -13,7 +13,6 @@ func init() {
 
 func TestPodImg(t *testing.T) {
 	fakePods := fakeaudit.GetPods("fakePodImg")
-	wg.Add(2)
 	image := imgFlags{img: "fakeContainerImg:1.5"}
 	image.splitImageString()
 	results := auditImages(image, kubeAuditPods{list: fakePods})

--- a/cmd/privileged_test.go
+++ b/cmd/privileged_test.go
@@ -13,7 +13,6 @@ func init() {
 
 func TestDaemonSetPrivileged(t *testing.T) {
 	fakeDaemonSets := fakeaudit.GetDaemonSets("fakeDaemonSetPrivileged")
-	wg.Add(1)
 	results := auditPrivileged(kubeAuditDaemonSets{list: fakeDaemonSets})
 
 	if len(results) != 3 {

--- a/cmd/readOnlyRootFilesystem_test.go
+++ b/cmd/readOnlyRootFilesystem_test.go
@@ -13,7 +13,6 @@ func init() {
 
 func TestStatefulSetRORF(t *testing.T) {
 	fakeStatefulSets := fakeaudit.GetStatefulSets("fakeStatefulSetRORF")
-	wg.Add(1)
 	results := auditReadOnlyRootFS(kubeAuditStatefulSets{list: fakeStatefulSets})
 
 	if len(results) != 3 {

--- a/cmd/runAsNonRoot_test.go
+++ b/cmd/runAsNonRoot_test.go
@@ -13,7 +13,6 @@ func init() {
 
 func TestDeploymentRANR(t *testing.T) {
 	fakeDeployments := fakeaudit.GetDeployments("fakeDeploymentRANR")
-	wg.Add(1)
 	results := auditRunAsNonRoot(kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 3 {

--- a/cmd/securityContext_test.go
+++ b/cmd/securityContext_test.go
@@ -29,7 +29,6 @@ func TestCapsNotDropped(t *testing.T) {
 
 func TestDeploymentSC(t *testing.T) {
 	fakeDeployments := fakeaudit.GetDeployments("fakeDeploymentSC")
-	wg.Add(1)
 	results := auditSecurityContext(kubeAuditDeployments{list: fakeDeployments})
 
 	if len(results) != 4 {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -3,14 +3,11 @@ package cmd
 import (
 	"reflect"
 	"runtime"
-	"sync"
 
 	fakeaudit "github.com/Shopify/kubeaudit/fakeaudit"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 )
-
-var wg sync.WaitGroup
 
 func debugPrint() {
 	if rootConfig.verbose == "DEBUG" {


### PR DESCRIPTION
Fixes https://github.com/Shopify/kubeaudit/issues/52. I've refactored it to in a way that I think is cleaner because:

- The WaitGroup usage is all in one place, one can see all the calls instead of having it on diff functions
- No global WaitGroup

Let me know what you think.