### PR TITLE
Refactor audit command run code into a util function

### DIFF
--- a/cmd/automountServiceAccountToken.go
+++ b/cmd/automountServiceAccountToken.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"sync"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -39,9 +36,6 @@ func auditAutomountServiceAccountToken(items Items) (results []Result) {
 			results = append(results, *result)
 		}
 	}
-	for _, result := range results {
-		result.Print()
-	}
 	return
 }
 
@@ -61,38 +55,7 @@ Fix this by updating serviceAccount to serviceAccountName in your .yamls
 
 Example usage:
 kubeaudit rbac sat`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if rootConfig.json {
-			log.SetFormatter(&log.JSONFormatter{})
-		}
-		var resources []Items
-
-		if rootConfig.manifest != "" {
-			var err error
-			resources, err = getKubeResourcesManifest(rootConfig.manifest)
-			if err != nil {
-				log.Error(err)
-			}
-		} else {
-			kube, err := kubeClient(rootConfig.kubeConfig)
-			if err != nil {
-				log.Error(err)
-			}
-			resources = getKubeResources(kube)
-		}
-
-		var wg sync.WaitGroup
-		wg.Add(len(resources))
-
-		for _, resource := range resources {
-			go func(items Items) {
-				auditAutomountServiceAccountToken(items)
-				wg.Done()
-			}(resource)
-		}
-
-		wg.Wait()
-	},
+	Run: runAudit(auditAutomountServiceAccountToken),
 }
 
 func init() {

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"strings"
-	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -79,48 +77,7 @@ This command is also a root command, check kubeaudit sc --help
 Example usage:
 kubeaudit image --image gcr.io/google_containers/echoserver:1.7
 kubeaudit image -i gcr.io/google_containers/echoserver:1.7`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(imgConfig.img) == 0 {
-			log.Error("Empty image name. Are you missing the image flag?")
-			return
-		}
-		imgConfig.splitImageString()
-		if len(imgConfig.tag) == 0 {
-			log.Error("Empty image tag. Are you missing the image tag?")
-			return
-		}
-
-		if rootConfig.json {
-			log.SetFormatter(&log.JSONFormatter{})
-		}
-		var resources []Items
-
-		if rootConfig.manifest != "" {
-			var err error
-			resources, err = getKubeResourcesManifest(rootConfig.manifest)
-			if err != nil {
-				log.Error(err)
-			}
-		} else {
-			kube, err := kubeClient(rootConfig.kubeConfig)
-			if err != nil {
-				log.Error(err)
-			}
-			resources = getKubeResources(kube)
-		}
-
-		var wg sync.WaitGroup
-		wg.Add(len(resources))
-
-		for _, resource := range resources {
-			go func(items Items) {
-				auditImages(imgConfig, items)
-				wg.Done()
-			}(resource)
-		}
-
-		wg.Wait()
-	},
+	Run: runAudit(auditImages),
 }
 
 func init() {

--- a/cmd/privileged.go
+++ b/cmd/privileged.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"sync"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -55,39 +52,7 @@ A FAIL is generated when a container runs in a privileged mode
 
 Example usage:
 kubeaudit privileged`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if rootConfig.json {
-			log.SetFormatter(&log.JSONFormatter{})
-		}
-		var resources []Items
-
-		if rootConfig.manifest != "" {
-			var err error
-			resources, err = getKubeResourcesManifest(rootConfig.manifest)
-			if err != nil {
-				log.Error(err)
-			}
-		} else {
-			kube, err := kubeClient(rootConfig.kubeConfig)
-			if err != nil {
-				log.Error(err)
-			}
-
-			resources = getKubeResources(kube)
-		}
-
-		var wg sync.WaitGroup
-		wg.Add(len(resources))
-
-		for _, resource := range resources {
-			go func(items Items) {
-				auditPrivileged(items)
-				wg.Done()
-			}(resource)
-		}
-
-		wg.Wait()
-	},
+	Run: runAudit(auditPrivileged),
 }
 
 func init() {

--- a/cmd/readOnlyRootFilesystem.go
+++ b/cmd/readOnlyRootFilesystem.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"sync"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -52,38 +49,7 @@ A FAIL is given when a container does not have a read only root filesystem
 
 Example usage:
 kubeaudit runAsNonRoot`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if rootConfig.json {
-			log.SetFormatter(&log.JSONFormatter{})
-		}
-		var resources []Items
-
-		if rootConfig.manifest != "" {
-			var err error
-			resources, err = getKubeResourcesManifest(rootConfig.manifest)
-			if err != nil {
-				log.Error(err)
-			}
-		} else {
-			kube, err := kubeClient(rootConfig.kubeConfig)
-			if err != nil {
-				log.Error(err)
-			}
-			resources = getKubeResources(kube)
-		}
-
-		var wg sync.WaitGroup
-		wg.Add(len(resources))
-
-		for _, resource := range resources {
-			go func(items Items) {
-				auditReadOnlyRootFS(items)
-				wg.Done()
-			}(resource)
-		}
-
-		wg.Wait()
-	},
+	Run: runAudit(auditReadOnlyRootFS),
 }
 
 func init() {


### PR DESCRIPTION
Fixes channel issues causing https://github.com/Shopify/kubeaudit/pull/61, as well as further refactoring the `runAudit` and `runImageAudit` util functions into one single function. 