### PR TITLE
Quota cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ audits against pods in all the phases (default Running Phase)
 - [Audit image](#image)
 - [Audit Service Accounts](#sat)
 - [Audit network policies](#netpol)
+- [Audit resources](#resources)
 
 <a name="sc" />
 
@@ -247,6 +248,27 @@ for more information:
 # don't specify -l or -c to run inside the clsuter
 kubeaudit np
 WARN[0000] Default allow mode on test/testing
+```
+
+<a name="resources" />
+
+### Audit resources limits
+
+It checks that every resource has a CPU and memory limit. See [Kubernetes Resource Quotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/)
+for more information:
+
+```sh
+kubeaudit -l limits
+WARN[0000] CPU limit not set, please set it!
+WARN[0000] Memory limit not set, please set it!
+```
+
+With the `--cpu` and `--memory` parameters, `kubeaudit` can check the limits not to be exceeded.
+
+```sh
+kubeaudit -l limits --cpu 500m --memory 125Mi
+WARN[0000] CPU limit exceeded, it is set to 1 but it must not exceed 500m. Please adjust it! !
+WARN[0000] Memory limit exceeded, it is set to 512Mi but it must not exceed 125Mi. Please adjust it!
 ```
 
 <a name="contribute" />

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -15,6 +15,11 @@ const (
 	ErrorPrivilegedTrue
 	ErrorReadOnlyRootFilesystemFalse
 	ErrorReadOnlyRootFilesystemNIL
+	ErrorResourcesLimitsNIL
+	ErrorResourcesLimitsCpuNIL
+	ErrorResourcesLimitsCpuExceeded
+	ErrorResourcesLimitsMemoryNIL
+	ErrorResourcesLimitsMemoryExceeded
 	ErrorRunAsNonRootFalse
 	ErrorRunAsNonRootNIL
 	ErrorSecurityContextNIL

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	k8sResource "k8s.io/apimachinery/pkg/api/resource"
+)
+
+type limitFlags struct {
+	cpuArg    string
+	cpu       k8sResource.Quantity
+	memoryArg string
+	memory    k8sResource.Quantity
+}
+
+var limitConfig limitFlags
+
+func (limit *limitFlags) parseLimitFlags() {
+	if len(limit.cpuArg) != 0 {
+		quantity, err := k8sResource.ParseQuantity(limit.cpuArg)
+		if err != nil {
+			log.Error("Wrong cpu argument: " + err.Error())
+			return
+		}
+		limit.cpu = quantity
+	}
+
+	if len(limit.memoryArg) != 0 {
+		quantity, err := k8sResource.ParseQuantity(limit.memoryArg)
+		if err != nil {
+			log.Error("Wrong cpu argument: " + err.Error())
+			return
+		}
+		limit.memory = quantity
+	}
+}
+
+func checkLimits(container Container, limits limitFlags, result *Result) {
+	if container.Resources.Limits == nil {
+		occ := Occurrence{id: ErrorResourcesLimitsNIL, kind: Warn, message: "Resource limit not set, please set it!"}
+		result.Occurrences = append(result.Occurrences, occ)
+		return
+	}
+
+	checkCPULimit(container, limits, result)
+	checkMemoryLimit(container, limits, result)
+}
+
+func checkCPULimit(container Container, limits limitFlags, result *Result) {
+	cpu := container.Resources.Limits.Cpu()
+	if cpu == nil || cpu.IsZero() {
+		occ := Occurrence{id: ErrorResourcesLimitsCpuNIL, kind: Warn, message: "CPU limit not set, please set it!"}
+		result.Occurrences = append(result.Occurrences, occ)
+		return
+	}
+
+	if limits.cpu.MilliValue() > 0 && cpu.MilliValue() > limits.cpu.MilliValue() {
+		result.CPULimitActual = cpu.String()
+		result.CPULimitMax = limits.cpu.String()
+		message := fmt.Sprintf("CPU limit exceeded, it is set to %s but it must not exceed %s. Please adjust it!", cpu.String(), limits.cpu.String())
+		occ := Occurrence{id: ErrorResourcesLimitsCpuExceeded, kind: Warn, message: message}
+		result.Occurrences = append(result.Occurrences, occ)
+	}
+}
+
+func checkMemoryLimit(container Container, limits limitFlags, result *Result) {
+	memory := container.Resources.Limits.Memory()
+	if memory == nil || memory.IsZero() {
+		occ := Occurrence{id: ErrorResourcesLimitsMemoryNIL, kind: Warn, message: "Memory limit not set, please set it!"}
+		result.Occurrences = append(result.Occurrences, occ)
+		return
+	}
+
+	if limits.memory.Value() > 0 && memory.Value() > limits.memory.Value() {
+		result.MEMLimitActual = memory.String()
+		result.MEMLimitMax = limits.memory.String()
+		message := fmt.Sprintf("Memory limit exceeded, it is set to %s but it must not exceed %s. Please adjust it!", memory.String(), limits.memory.String())
+		occ := Occurrence{id: ErrorResourcesLimitsMemoryExceeded, kind: Warn, message: message}
+		result.Occurrences = append(result.Occurrences, occ)
+	}
+}
+
+func auditLimits(limits limitFlags, items Items) (results []Result) {
+	limits.parseLimitFlags()
+
+	for _, item := range items.Iter() {
+		containers, result := containerIter(item)
+		for _, container := range containers {
+			checkLimits(container, limits, result)
+			if result != nil && len(result.Occurrences) > 0 {
+				results = append(results, *result)
+				break
+			}
+		}
+	}
+	return
+}
+
+var limitsCmd = &cobra.Command{
+	Use:   "limits",
+	Short: "Audit containers running with limits",
+	Long: `This command determines which containers in a kubernetes cluster have and do not exceed specified cpu and memory limits.
+
+A PASS is given when a container has cpu and memory limits
+A FAIL is given when a container does not have cpu and memory limits
+
+Example usage:
+kubeaudit limits
+kubeaudit limits --cpu 500m --memory 256Mi`,
+	Run: runAudit(auditLimits),
+}
+
+func init() {
+	RootCmd.AddCommand(limitsCmd)
+	limitsCmd.Flags().StringVar(&limitConfig.cpuArg, "cpu", "", "max cpu limit")
+	limitsCmd.Flags().StringVar(&limitConfig.memoryArg, "memory", "", "max memory limit")
+}

--- a/cmd/limits_test.go
+++ b/cmd/limits_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import "testing"
+
+func TestResourcesLimitsNil(t *testing.T) {
+	runTest(t, "resources_limit_nil.yml", auditLimits, ErrorResourcesLimitsNIL)
+}
+
+func TestResourcesNoCPULimit(t *testing.T) {
+	runTest(t, "resources_limit_no_cpu.yml", auditLimits, ErrorResourcesLimitsCpuNIL)
+}
+
+func TestResourcesNoMemoryLimit(t *testing.T) {
+	runTest(t, "resources_limit_no_memory.yml", auditLimits, ErrorResourcesLimitsMemoryNIL)
+}
+func TestResourcesCPULimitExceeded(t *testing.T) {
+	runTest(t, "resources_limit.yml", auditLimits, ErrorResourcesLimitsCpuExceeded, "600m", "")
+}
+
+func TestResourcesMemoryLimitExceeded(t *testing.T) {
+	runTest(t, "resources_limit.yml", auditLimits, ErrorResourcesLimitsMemoryExceeded, "", "384")
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -96,6 +96,10 @@ type Result struct {
 	SA             string
 	Token          *bool
 	ImageTag       string
+	CPULimitActual string
+	CPULimitMax    string
+	MEMLimitActual string
+	MEMLimitMax    string
 }
 
 func (res Result) Print() {
@@ -143,6 +147,12 @@ func shouldLog(err int) (members []string) {
 	case ErrorImageTagIncorrect:
 		members = append(members, "ImageTag")
 		members = append(members, "ImageName")
+	case ErrorResourcesLimitsCpuExceeded:
+		members = append(members, "CPULimitActual")
+		members = append(members, "CPULimitMax")
+	case ErrorResourcesLimitsMemoryExceeded:
+		members = append(members, "MEMLimitActual")
+		members = append(members, "MEMLimitMax")
 	}
 	return
 }
@@ -422,6 +432,8 @@ func runAudit(auditFunc interface{}) func(cmd *cobra.Command, args []string) {
 					resultsChannel <- append(results, f(item)...)
 				case func(image imgFlags, item Items) (results []Result):
 					resultsChannel <- append(results, f(imgConfig, item)...)
+				case func(limits limitFlags, item Items) (results []Result):
+					resultsChannel <- append(results, f(limitConfig, item)...)
 				default:
 					log.Fatal("Invalid audit function provided")
 				}

--- a/fixtures/resources_limit.yml
+++ b/fixtures/resources_limit.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: resources_limit_no_memory
+  namespace: fakeDeploymentQuota
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeNoLimitQuota
+    spec:
+      containers:
+      - name: fakeContainerLimitOk
+        resources: 
+          requests:
+            memory: 256Mi
+            cpu: 500m
+          limits:
+            memory: 512Mi
+            cpu: 750m
+

--- a/fixtures/resources_limit_nil.yml
+++ b/fixtures/resources_limit_nil.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: resources_limit_nil
+  namespace: fakeDeploymentQuota
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeNoLimitQuota
+    spec:
+      containers:
+      - name: fakeContainerNoLimit
+        resources:

--- a/fixtures/resources_limit_no_cpu.yml
+++ b/fixtures/resources_limit_no_cpu.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: resources_limit_no_cpu
+  namespace: fakeDeploymentQuota
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeNoLimitQuota
+    spec:
+      containers:
+      - name: fakeContainerNoCPULimit
+        resources: 
+          limits:
+            memory: 512Mi
+

--- a/fixtures/resources_limit_no_memory.yml
+++ b/fixtures/resources_limit_no_memory.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: resources_limit_no_memory
+  namespace: fakeDeploymentQuota
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeNoLimitQuota
+    spec:
+      containers:
+      - name: fakeContainerNoMemoryLimit
+        resources: 
+          limits:
+            cpu: 1000m
+


### PR DESCRIPTION
Hi,

Setting CPU and memory limits is a good security practice. (see http://blog.kubernetes.io/2016/08/security-best-practices-kubernetes-deployment.html)
Why not test this with a kubeaudit command?

What do you think of this notion and my implementation?
Your feedbacks are very welcome.

Regards,
Jeremie.