### PR TITLE
Auditing for specific namespace (with -n or --namespace option)

### DIFF
--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	apiv1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/version"
@@ -45,7 +44,7 @@ func kubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
 }
 
 func getDeployments(clientset *kubernetes.Clientset) *DeploymentList {
-	deploymentClient := clientset.AppsV1beta1().Deployments(apiv1.NamespaceAll)
+	deploymentClient := clientset.AppsV1beta1().Deployments(rootConfig.namespace)
 	deployments, err := deploymentClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
@@ -54,7 +53,7 @@ func getDeployments(clientset *kubernetes.Clientset) *DeploymentList {
 }
 
 func getStatefulSets(clientset *kubernetes.Clientset) *StatefulSetList {
-	statefulSetClient := clientset.AppsV1beta1().StatefulSets(apiv1.NamespaceAll)
+	statefulSetClient := clientset.AppsV1beta1().StatefulSets(rootConfig.namespace)
 	statefulSets, err := statefulSetClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
@@ -63,7 +62,7 @@ func getStatefulSets(clientset *kubernetes.Clientset) *StatefulSetList {
 }
 
 func getDaemonSets(clientset *kubernetes.Clientset) *DaemonSetList {
-	daemonSetClient := clientset.ExtensionsV1beta1().DaemonSets(apiv1.NamespaceAll)
+	daemonSetClient := clientset.ExtensionsV1beta1().DaemonSets(rootConfig.namespace)
 	daemonSets, err := daemonSetClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
@@ -72,7 +71,7 @@ func getDaemonSets(clientset *kubernetes.Clientset) *DaemonSetList {
 }
 
 func getPods(clientset *kubernetes.Clientset) *PodList {
-	podClient := clientset.CoreV1().Pods(apiv1.NamespaceAll)
+	podClient := clientset.CoreV1().Pods(rootConfig.namespace)
 	pods, err := podClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
@@ -81,7 +80,7 @@ func getPods(clientset *kubernetes.Clientset) *PodList {
 }
 
 func getReplicationControllers(clientset *kubernetes.Clientset) *ReplicationControllerList {
-	replicationControllerClient := clientset.CoreV1().ReplicationControllers(apiv1.NamespaceAll)
+	replicationControllerClient := clientset.CoreV1().ReplicationControllers(rootConfig.namespace)
 	replicationControllers, err := replicationControllerClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)
@@ -90,7 +89,7 @@ func getReplicationControllers(clientset *kubernetes.Clientset) *ReplicationCont
 }
 
 func getNetworkPolicies(clientset *kubernetes.Clientset) *networking.NetworkPolicyList {
-	netPolClient := clientset.NetworkingV1().NetworkPolicies(apiv1.NamespaceAll)
+	netPolClient := clientset.NetworkingV1().NetworkPolicies(rootConfig.namespace)
 	netPols, err := netPolClient.List(ListOptions{})
 	if err != nil {
 		log.Error(err)

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestDaemonSetInNamespace(t *testing.T) {
+	runTestInNamespace(t, "fakeDaemonSetPrivileged", "privileged_true.yml", auditPrivileged, ErrorPrivilegedTrue)
+}
+
+func TestDaemonSetNotInNamespace(t *testing.T) {
+	runTestInNamespace(t, "otherFakeDaemonSetPrivileged", "privileged_true.yml", auditPrivileged)
+}
+
+func TestDeploymentInNamespace(t *testing.T) {
+	runTestInNamespace(t, "fakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilitiesSomeDropped)
+}
+
+func TestDeploymentNotInNamespace(t *testing.T) {
+	runTestInNamespace(t, "otherFakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities)
+}
+
+func TestStatefulSetInNamespace(t *testing.T) {
+	runTestInNamespace(t, "fakeStatefulSetRORF", "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemNIL)
+}
+
+func TestStatefulSetNotInNamespace(t *testing.T) {
+	runTestInNamespace(t, "otherFakeStatefulSetRORF", "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS)
+}
+
+func TestReplicationControllerInNamespace(t *testing.T) {
+	runTestInNamespace(t, "fakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorServiceAccountTokenNILAndNoName)
+}
+
+func TestReplicationControllerNotInNamespace(t *testing.T) {
+	runTestInNamespace(t, "otherFakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	apiv1 "k8s.io/api/core/v1"
 )
 
 var rootConfig rootFlags
@@ -15,6 +16,7 @@ type rootFlags struct {
 	kubeConfig string
 	localMode  bool
 	manifest   string
+	namespace  string
 	verbose    string
 }
 
@@ -41,5 +43,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.localMode, "local", "l", false, "Local mode, uses ~/.kube/config as configuration")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.json, "json", "j", false, "Enable json logging")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.allPods, "allPods", "a", false, "Audit againsts pods in all the phases (default Running Phase)")
+	RootCmd.PersistentFlags().StringVarP(&rootConfig.namespace, "namespace", "n", apiv1.NamespaceAll, "Specify the namespace scope to audit")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.manifest, "manifest", "f", "", "yaml configuration to audit")
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -9,6 +9,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -22,44 +24,57 @@ func debugPrint() {
 	}
 }
 
+func isInRootConfigNamespace(meta metav1.ObjectMeta) (valid bool) {
+	return isInNamespace(meta, rootConfig.namespace)
+}
+
+func isInNamespace(meta metav1.ObjectMeta, namespace string) (valid bool) {
+	return namespace == apiv1.NamespaceAll || namespace == meta.Namespace
+}
+
 func convertDeploymentToDeploymentList(deployment Deployment) (deploymentList *DeploymentList) {
-	deploymentList = &DeploymentList{
-		Items: []Deployment{deployment},
+	if isInRootConfigNamespace(deployment.ObjectMeta) {
+		deploymentList = &DeploymentList{Items: []Deployment{deployment}}
+	} else {
+		deploymentList = &DeploymentList{Items: []Deployment{}}
 	}
 	return
-
 }
 
 func convertDaemonSetToDaemonSetList(daemonSet DaemonSet) (daemonSetList *DaemonSetList) {
-	daemonSetList = &DaemonSetList{
-		Items: []DaemonSet{daemonSet},
+	if isInRootConfigNamespace(daemonSet.ObjectMeta) {
+		daemonSetList = &DaemonSetList{Items: []DaemonSet{daemonSet}}
+	} else {
+		daemonSetList = &DaemonSetList{Items: []DaemonSet{}}
 	}
 	return
-
 }
 
 func convertPodToPodList(pod Pod) (podList *PodList) {
-	podList = &PodList{
-		Items: []Pod{pod},
+	if isInRootConfigNamespace(pod.ObjectMeta) {
+		podList = &PodList{Items: []Pod{pod}}
+	} else {
+		podList = &PodList{Items: []Pod{}}
 	}
 	return
-
 }
 
 func convertStatefulSetToStatefulSetList(statefulSet StatefulSet) (statefulSetList *StatefulSetList) {
-	statefulSetList = &StatefulSetList{
-		Items: []StatefulSet{statefulSet},
+	if isInRootConfigNamespace(statefulSet.ObjectMeta) {
+		statefulSetList = &StatefulSetList{Items: []StatefulSet{statefulSet}}
+	} else {
+		statefulSetList = &StatefulSetList{Items: []StatefulSet{}}
 	}
 	return
-
 }
 
 func convertReplicationControllerToReplicationList(replicationController ReplicationController) (replicationControllerList *ReplicationControllerList) {
-	replicationControllerList = &ReplicationControllerList{
-		Items: []ReplicationController{replicationController},
+	if isInRootConfigNamespace(replicationController.ObjectMeta) {
+		replicationControllerList = &ReplicationControllerList{Items: []ReplicationController{replicationController}}
+	} else {
+		replicationControllerList = &ReplicationControllerList{Items: []ReplicationController{}}
 	}
 	return
-
 }
 
 type kubeAuditDeployments struct {


### PR DESCRIPTION
Limiting auditing to a namespace can be useful in some cases.
I propose to add the `-n` or `--namespace` option to do this.

```
kubeaudit -l sat -n default
ERRO[0000] Default serviceAccount with token mounted. Please set AutomountServiceAccountToken to false  KubeType=deployment Name=redis Namespace=default
```
If nothing is indicated, all namespaces are taken into account as currently.

What do you think about this option?