### PR TITLE
Add options to override audits using labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /vendor
 coverage.txt
 /dist
+*.swp

--- a/cmd/allowPrivilegeEscalation_test.go
+++ b/cmd/allowPrivilegeEscalation_test.go
@@ -15,3 +15,11 @@ func TestAllowPrivilegeEscalationNil(t *testing.T) {
 func TestAllowPrivilegeEscalationTrue(t *testing.T) {
 	runTest(t, "allow_privilege_escalation_true.yml", auditAllowPrivilegeEscalation, ErrorAllowPrivilegeEscalationTrue)
 }
+
+func TestAllowPrivilegeEscalationTrueAllowed(t *testing.T) {
+	runTest(t, "allow_privilege_escalation_true_allowed.yml", auditAllowPrivilegeEscalation, ErrorAllowPrivilegeEscalationTrueAllowed)
+}
+
+func TestAllowPrivilegeEscalationMisconfiguredAllow(t *testing.T) {
+	runTest(t, "allow_privilege_escalation_misconfigured_allow.yml", auditAllowPrivilegeEscalation, ErrorMisconfiguredKubeauditAllow)
+}

--- a/cmd/automountServiceAccountToken_test.go
+++ b/cmd/automountServiceAccountToken_test.go
@@ -7,9 +7,17 @@ func TestServiceAccountTokenDeprecated(t *testing.T) {
 }
 
 func TestServiceAccountTokenTrueAndNoName(t *testing.T) {
-	runTest(t, "service_account_token_true_and_no_name.yml", auditAutomountServiceAccountToken, ErrorServiceAccountTokenTrueAndNoName)
+	runTest(t, "service_account_token_true_and_no_name.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenTrueAndNoName)
 }
 
 func TestServiceAccountTokenNILAndNoName(t *testing.T) {
-	runTest(t, "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorServiceAccountTokenNILAndNoName)
+	runTest(t, "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenNILAndNoName)
+}
+
+func TestServiceAccountTokenTrueAllowed(t *testing.T) {
+	runTest(t, "service_account_token_true_allowed.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenTrueAllowed)
+}
+
+func TestServiceAccountTokenMisconfiguredAllow(t *testing.T) {
+	runTest(t, "service_account_token_misconfigured_allow.yml", auditAutomountServiceAccountToken, ErrorMisconfiguredKubeauditAllow)
 }

--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -10,15 +10,7 @@ func TestRecommendedCapabilitiesToBeDropped(t *testing.T) {
 	assert := assert.New(t)
 	capabilities, err := recommendedCapabilitiesToBeDropped()
 	assert.Nil(err)
-	assert.Equal([]Capability{"AUDIT_WRITE", "CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETUID", "SETPCAP", "SYS_CHROOT"}, capabilities, "")
-}
-
-func TestCapsNotDropped(t *testing.T) {
-	assert := assert.New(t)
-	caps := []Capability{"CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETUID", "SETPCAP", "SYS_CHROOT"}
-	notDropped, err := capsNotDropped(caps)
-	assert.Nil(err)
-	assert.Equal([]Capability{"AUDIT_WRITE"}, notDropped, "")
+	assert.Equal(arrayToCapSet([]Capability{"AUDIT_WRITE", "CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETUID", "SETPCAP", "SYS_CHROOT"}), capabilities, "")
 }
 
 func TestSecurityContextNIL_SC(t *testing.T) {
@@ -30,13 +22,17 @@ func TestCapabilitiesNIL(t *testing.T) {
 }
 
 func TestCapabilitiesAdded(t *testing.T) {
-	runTest(t, "capabilities_added.yml", auditCapabilities, ErrorCapabilitiesAdded)
+	runTest(t, "capabilities_added.yml", auditCapabilities, ErrorCapabilityAdded)
 }
 
-func TestCapabilitiesNoneDropped(t *testing.T) {
-	runTest(t, "capabilities_none_dropped.yml", auditCapabilities, ErrorCapabilitiesNoneDropped)
+func TestCapabilitiesSomeAllowed(t *testing.T) {
+	runTest(t, "capabilities_some_allowed.yml", auditCapabilities, ErrorCapabilityAllowed)
 }
 
 func TestCapabilitiesSomeDropped(t *testing.T) {
-	runTest(t, "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilitiesSomeDropped)
+	runTest(t, "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilityNotDropped)
+}
+
+func TestCapabilitiesMisconfiguredAllow(t *testing.T) {
+	runTest(t, "capabilities_misconfigured_allow.yml", auditCapabilities, ErrorMisconfiguredKubeauditAllow)
 }

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -4,16 +4,20 @@ const (
 	_ = iota
 	KubeauditInternalError
 	ErrorAllowPrivilegeEscalationNIL
+	ErrorAllowPrivilegeEscalationTrueAllowed
 	ErrorAllowPrivilegeEscalationTrue
-	ErrorCapabilitiesAdded
+	ErrorCapabilityAdded
+	ErrorCapabilityAllowed
 	ErrorCapabilitiesNIL
 	ErrorCapabilitiesNoneDropped
-	ErrorCapabilitiesSomeDropped
+	ErrorCapabilityNotDropped
 	ErrorImageTagIncorrect
 	ErrorImageTagMissing
 	ErrorPrivilegedNIL
 	ErrorPrivilegedTrue
+	ErrorPrivilegedTrueAllowed
 	ErrorReadOnlyRootFilesystemFalse
+	ErrorReadOnlyRootFilesystemFalseAllowed
 	ErrorReadOnlyRootFilesystemNIL
 	ErrorResourcesLimitsNIL
 	ErrorResourcesLimitsCpuNIL
@@ -22,11 +26,13 @@ const (
 	ErrorResourcesLimitsMemoryExceeded
 	ErrorRunAsNonRootFalse
 	ErrorRunAsNonRootNIL
+	ErrorRunAsNonRootFalseAllowed
 	ErrorSecurityContextNIL
 	ErrorServiceAccountTokenDeprecated
-	ErrorServiceAccountTokenNIL
-	ErrorServiceAccountTokenNILAndNoName
+	ErrorAutomountServiceAccountTokenNILAndNoName
 	ErrorServiceAccountTokenNoName
-	ErrorServiceAccountTokenTrueAndNoName
+	ErrorAutomountServiceAccountTokenTrueAndNoName
+	ErrorAutomountServiceAccountTokenTrueAllowed
+	ErrorMisconfiguredKubeauditAllow
 	InfoImageCorrect
 )

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -13,11 +13,11 @@ func TestDaemonSetNotInNamespace(t *testing.T) {
 }
 
 func TestDeploymentInNamespace(t *testing.T) {
-	runTestInNamespace(t, "fakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilitiesSomeDropped)
+	runTestInNamespace(t, "fakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilityNotDropped)
 }
 
 func TestDeploymentNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilitiesSomeDropped)
+	runTestInNamespace(t, "otherFakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilityNotDropped)
 }
 
 func TestStatefulSetInNamespace(t *testing.T) {
@@ -29,9 +29,9 @@ func TestStatefulSetNotInNamespace(t *testing.T) {
 }
 
 func TestReplicationControllerInNamespace(t *testing.T) {
-	runTestInNamespace(t, "fakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorServiceAccountTokenNILAndNoName)
+	runTestInNamespace(t, "fakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenNILAndNoName)
 }
 
 func TestReplicationControllerNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorServiceAccountTokenNILAndNoName)
+	runTestInNamespace(t, "otherFakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenNILAndNoName)
 }

--- a/cmd/occurrence.go
+++ b/cmd/occurrence.go
@@ -1,7 +1,8 @@
 package cmd
 
 type Occurrence struct {
-	kind    int    // or int? just needs to represent  {debug, log, warn, error}
-	id      int    // KubeAuditInfo, ErrorImageTagMissing ...
-	message string // the message that currently is in the printResultX function, which would go away with the introduction of this
+	kind     int    // or int? just needs to represent  {debug, log, warn, error}
+	id       int    // KubeAuditInfo, ErrorImageTagMissing ...
+	message  string // the message that currently is in the printResultX function, which would go away with the introduction of this
+	metadata Metadata
 }

--- a/cmd/privileged_test.go
+++ b/cmd/privileged_test.go
@@ -13,3 +13,11 @@ func TestPrivilegedNIL(t *testing.T) {
 func TestPrivilegedTrue(t *testing.T) {
 	runTest(t, "privileged_true.yml", auditPrivileged, ErrorPrivilegedTrue)
 }
+
+func TestPrivilegedTrueAllowed(t *testing.T) {
+	runTest(t, "privileged_true_allowed.yml", auditPrivileged, ErrorPrivilegedTrueAllowed)
+}
+
+func TestPrivilegedMisconfiguredAllow(t *testing.T) {
+	runTest(t, "privileged_misconfigured_allow.yml", auditPrivileged, ErrorMisconfiguredKubeauditAllow)
+}

--- a/cmd/readOnlyRootFilesystem_test.go
+++ b/cmd/readOnlyRootFilesystem_test.go
@@ -13,3 +13,11 @@ func TestReadOnlyRootFilesystemNIL(t *testing.T) {
 func TestReadOnlyRootFilesystemFalse(t *testing.T) {
 	runTest(t, "read_only_root_filesystem_false.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemFalse)
 }
+
+func TestReadOnlyRootFilesystemFalseAllowed(t *testing.T) {
+	runTest(t, "read_only_root_filesystem_false_allowed.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemFalseAllowed)
+}
+
+func TestReadOnlyRootFilesystemMisconfiguredAllow(t *testing.T) {
+	runTest(t, "read_only_root_filesystem_misconfigured_allow.yml", auditReadOnlyRootFS, ErrorMisconfiguredKubeauditAllow)
+}

--- a/cmd/runAsNonRoot.go
+++ b/cmd/runAsNonRoot.go
@@ -8,17 +8,49 @@ import (
 
 func checkRunAsNonRoot(container Container, result *Result) {
 	if container.SecurityContext == nil {
-		occ := Occurrence{id: ErrorSecurityContextNIL, kind: Error, message: "SecurityContext not set, please set it!"}
+		occ := Occurrence{
+			id:      ErrorSecurityContextNIL,
+			kind:    Error,
+			message: "SecurityContext not set, please set it!",
+		}
 		result.Occurrences = append(result.Occurrences, occ)
 		return
 	}
+	if reason := result.Labels["kubeaudit.allow.runAsRoot"]; reason != "" {
+		if container.SecurityContext.RunAsNonRoot == nil || *container.SecurityContext.RunAsNonRoot == false {
+			occ := Occurrence{
+				id:       ErrorRunAsNonRootFalseAllowed,
+				kind:     Warn,
+				message:  "Allowed setting RunAsNonRoot to false",
+				metadata: Metadata{"Reason": prettifyReason(reason)},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		} else {
+			occ := Occurrence{
+				id:       ErrorMisconfiguredKubeauditAllow,
+				kind:     Warn,
+				message:  "Allowed setting RunAsNonRoot to false, but it is set to true",
+				metadata: Metadata{"Reason": prettifyReason(reason)},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		}
+		return
+	}
 	if container.SecurityContext.RunAsNonRoot == nil {
-		occ := Occurrence{id: ErrorRunAsNonRootNIL, kind: Error, message: "RunAsNonRoot is not set, which results in root user being allowed!"}
+		occ := Occurrence{
+			id:      ErrorRunAsNonRootNIL,
+			kind:    Error,
+			message: "RunAsNonRoot is not set, which results in root user being allowed!",
+		}
 		result.Occurrences = append(result.Occurrences, occ)
 		return
 	}
 	if *container.SecurityContext.RunAsNonRoot == false {
-		occ := Occurrence{id: ErrorRunAsNonRootFalse, kind: Error, message: "RunAsNonRoot is set to false (root user allowed), please set to true!"}
+		occ := Occurrence{
+			id:      ErrorRunAsNonRootFalse,
+			kind:    Error,
+			message: "RunAsNonRoot is set to false (root user allowed), please set to true!",
+		}
 		result.Occurrences = append(result.Occurrences, occ)
 	}
 }

--- a/cmd/runAsNonRoot_test.go
+++ b/cmd/runAsNonRoot_test.go
@@ -15,3 +15,11 @@ func TestRunAsNonRootNil(t *testing.T) {
 func TestRunAsNonRootFalse(t *testing.T) {
 	runTest(t, "run_as_non_root_false.yml", auditRunAsNonRoot, ErrorRunAsNonRootFalse)
 }
+
+func TestAllowRunAsRootFalseAllowed(t *testing.T) {
+	runTest(t, "run_as_non_root_false_allowed.yml", auditRunAsNonRoot, ErrorRunAsNonRootFalseAllowed)
+}
+
+func TestAllowRunAsNonRootMisconfiguredAllow(t *testing.T) {
+	runTest(t, "run_as_non_root_misconfigured_allow.yml", auditRunAsNonRoot, ErrorMisconfiguredKubeauditAllow)
+}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -26,3 +26,5 @@ type NetworkPolicyList = networking.NetworkPolicyList
 type Capability = apiv1.Capability
 type Container = apiv1.Container
 type ListOptions = metav1.ListOptions
+
+type Metadata = map[string]string

--- a/fixtures/allow_privilege_escalation_misconfigured_allow.yml
+++ b/fixtures/allow_privilege_escalation_misconfigured_allow.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: fakeStatefulSetAPE
+  namespace: fakeStatefulSetAPE
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeAllowPrivilegeEscalation
+        kubeaudit.allow.privilegeEscalation: "Superuser privileges needed"
+    spec:
+      containers:
+      - name: fakeContainerAPE
+        securityContext:
+            allowPrivilegeEscalation: false

--- a/fixtures/allow_privilege_escalation_true_allowed.yml
+++ b/fixtures/allow_privilege_escalation_true_allowed.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: fakeStatefulSetAPE
+  namespace: fakeStatefulSetAPE
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeAllowPrivilegeEscalation
+        kubeaudit.allow.privilegeEscalation: "Superuser privileges needed"
+    spec:
+      containers:
+      - name: fakeContainerAPE
+        securityContext:
+            privileged: true

--- a/fixtures/capabilities_misconfigured_allow.yml
+++ b/fixtures/capabilities_misconfigured_allow.yml
@@ -2,21 +2,19 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: cababilitiesAdded
+  name: fakeDeploymentCapabilitiesAllowed
   namespace: fakeDeploymentSC
 spec:
   template:
     metadata:
       labels:
         apps: fakeSecurityContext
+        kubeaudit.allow.capability.sys_time: "Time is of the essence"
     spec:
       containers:
       - name: fakeContainerSC
         securityContext:
           capabilities:
-            add:
-            - NET_ADMIN
-            - SYS_TIME
             drop:
             - AUDIT_WRITE
             - CHOWN

--- a/fixtures/capabilities_some_allowed.yml
+++ b/fixtures/capabilities_some_allowed.yml
@@ -2,24 +2,24 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: cababilitiesAdded
+  name: fakeDeploymentCapabilitiesAllowed
   namespace: fakeDeploymentSC
 spec:
   template:
     metadata:
       labels:
         apps: fakeSecurityContext
+        kubeaudit.allow.capability.chown: "True"
+        kubeaudit.allow.capability.sys_time: "Time is of the essence"
     spec:
       containers:
       - name: fakeContainerSC
         securityContext:
           capabilities:
             add:
-            - NET_ADMIN
             - SYS_TIME
             drop:
             - AUDIT_WRITE
-            - CHOWN
             - DAC_OVERRIDE
             - FOWNER
             - FSETID

--- a/fixtures/privileged_misconfigured_allow.yml
+++ b/fixtures/privileged_misconfigured_allow.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fakeDaemonSetPrivileged2
+  namespace: fakeDaemonSetPrivileged
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakePrivileged
+        kubeaudit.allow.privileged: "Privileged execution required"
+    spec:
+      containers:
+      - name: fakeContainerPrivileged
+        securityContext:
+            privileged: false

--- a/fixtures/privileged_true_allowed.yml
+++ b/fixtures/privileged_true_allowed.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fakeDaemonSetPrivileged2
+  namespace: fakeDaemonSetPrivileged
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakePrivileged
+        kubeaudit.allow.privileged: "Privileged execution required"
+    spec:
+      containers:
+      - name: fakeContainerPrivileged
+        securityContext:
+          privileged: true

--- a/fixtures/read_only_root_filesystem_false_allowed.yml
+++ b/fixtures/read_only_root_filesystem_false_allowed.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: fakeStatefulSetRORF3
+  namespace: fakeStatefulSetRORF
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeReadOnlyRootFilesystem
+        kubeaudit.allow.readOnlyRootFilesystemFalse: "Write permissions needed"
+    spec:
+      containers:
+      - name: fakeContainerRORF
+        securityContext:
+          readOnlyRootFilesystem: false

--- a/fixtures/read_only_root_filesystem_misconfigured_allow.yml
+++ b/fixtures/read_only_root_filesystem_misconfigured_allow.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: fakeStatefulSetRORF3
+  namespace: fakeStatefulSetRORF
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeReadOnlyRootFilesystem
+        kubeaudit.allow.readOnlyRootFilesystemFalse: "Write permissions needed"
+    spec:
+      containers:
+      - name: fakeContainerRORF
+        securityContext:
+          readOnlyRootFilesystem: true

--- a/fixtures/run_as_non_root_false_allowed.yml
+++ b/fixtures/run_as_non_root_false_allowed.yml
@@ -2,18 +2,16 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: cababilitiesAdded
-  namespace: fakeDeploymentSC
+  name: allow_run_as_root
+  namespace: fakeDeploymentRANR
 spec:
   template:
     metadata:
       labels:
         apps: fakeSecurityContext
+        kubeaudit.allow.runAsRoot: "Superuser privileges needed"
     spec:
       containers:
-      - name: fakeContainerSC
+      - name: fakeContainerRANR
         securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-            - SYS_TIME
+            runAsNonRoot: false

--- a/fixtures/run_as_non_root_misconfigured_allow.yml
+++ b/fixtures/run_as_non_root_misconfigured_allow.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: allow_run_as_root
+  namespace: fakeDeploymentRANR
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeSecurityContext
+        kubeaudit.allow.runAsRoot: "Superuser privileges needed"
+    spec:
+      containers:
+      - name: fakeContainerRANR
+        securityContext:
+            runAsNonRoot: true

--- a/fixtures/service_account_token_misconfigured_allow.yml
+++ b/fixtures/service_account_token_misconfigured_allow.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: fakeReplicationControllerASAT2
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeAutomountServiceAccountToken
+        kubeaudit.allow.automountServiceAccountToken: "True"
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: fakeContainerASAT

--- a/fixtures/service_account_token_true_allowed.yml
+++ b/fixtures/service_account_token_true_allowed.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: fakeReplicationControllerASAT2
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeAutomountServiceAccountToken
+        kubeaudit.allow.automountServiceAccountToken: "True"
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - name: fakeContainerASAT


### PR DESCRIPTION
This PR adds support for the following labels:
    - `kubeaudit.allow.privilegeEscalation`: Allows setting `AllowPrivilegeEscalation` to true
    - `kubeaudit.alllow.privileged`: Allows setting `Privileged` to true
    - `kubeaudit.allow.capability.{{capName}}`: Allows the addition/retention of specified capability
    - `kubeaudit.allow.runAsRoot`: Allows setting `runAsNonRoot` to false
    - `kubeaudit.allow.automountServiceAccountToken`: Allows setting `automountServiceAccountToken` to true
    - `kubeaudit.allow.readOnlyRootFilesystemFalse`: Allows setting readOnlyRootFilesystem to false  

The labels will override their respective audits when their value is not nil. The value will be interpreted as the `Reason` said override was implemented, with a value of `"True"` or `"true"` being interpreted as `"Unspecified"`. 