### PR TITLE
Refactor util.go, deletes all kubeaudit types

### DIFF
--- a/cmd/automountServiceAccountToken.go
+++ b/cmd/automountServiceAccountToken.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 func checkAutomountServiceAccountToken(result *Result) {
@@ -27,19 +28,15 @@ func checkAutomountServiceAccountToken(result *Result) {
 	}
 }
 
-func auditAutomountServiceAccountToken(items Items) (results []Result) {
-	for _, item := range items.Iter() {
-		result := ServiceAccountIter(item)
-		checkAutomountServiceAccountToken(result)
-
-		if result != nil && len(result.Occurrences) > 0 {
-			results = append(results, *result)
-		}
+func auditAutomountServiceAccountToken(resource k8sRuntime.Object) (results []Result) {
+	result := newResultFromResourceWithServiceAccountInfo(resource)
+	checkAutomountServiceAccountToken(&result)
+	if len(result.Occurrences) > 0 {
+		results = append(results, result)
 	}
 	return
 }
 
-// satCmd represents the sat command
 var satCmd = &cobra.Command{
 	Use:   "sat",
 	Short: "Audit automountServiceAccountToken = true pods against an empty (default) service account",

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 type capsDropList struct {
@@ -85,15 +86,13 @@ func checkCapabilities(container Container, result *Result) {
 	}
 }
 
-func auditCapabilities(items Items) (results []Result) {
-	for _, item := range items.Iter() {
-		containers, result := containerIter(item)
-		for _, container := range containers {
-			checkCapabilities(container, result)
-			if result != nil && len(result.Occurrences) > 0 {
-				results = append(results, *result)
-				break
-			}
+func auditCapabilities(resource k8sRuntime.Object) (results []Result) {
+	for _, container := range getContainers(resource) {
+		result := newResultFromResource(resource)
+		checkCapabilities(container, &result)
+		if len(result.Occurrences) > 0 {
+			results = append(results, result)
+			break
 		}
 	}
 	return

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -15,12 +15,9 @@ import (
 
 func kubeClientConfig(kubeconfig string) (*rest.Config, error) {
 	if kubeconfig == "" && !rootConfig.localMode {
-		fmt.Println("Inside cluster. Not using kube config")
-		// creates the in-cluster config
+		fmt.Println("Running inside cluster, using the cluster config")
 		return rest.InClusterConfig()
 	}
-
-	// generate config from kubectl config current-context
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
 }
 

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -9,7 +9,7 @@ func TestDaemonSetInNamespace(t *testing.T) {
 }
 
 func TestDaemonSetNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeDaemonSetPrivileged", "privileged_true.yml", auditPrivileged)
+	runTestInNamespace(t, "otherFakeDaemonSetPrivileged", "privileged_true.yml", auditPrivileged, ErrorPrivilegedTrue)
 }
 
 func TestDeploymentInNamespace(t *testing.T) {
@@ -17,7 +17,7 @@ func TestDeploymentInNamespace(t *testing.T) {
 }
 
 func TestDeploymentNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities)
+	runTestInNamespace(t, "otherFakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilitiesSomeDropped)
 }
 
 func TestStatefulSetInNamespace(t *testing.T) {
@@ -25,7 +25,7 @@ func TestStatefulSetInNamespace(t *testing.T) {
 }
 
 func TestStatefulSetNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeStatefulSetRORF", "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS)
+	runTestInNamespace(t, "otherFakeStatefulSetRORF", "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemNIL)
 }
 
 func TestReplicationControllerInNamespace(t *testing.T) {
@@ -33,5 +33,5 @@ func TestReplicationControllerInNamespace(t *testing.T) {
 }
 
 func TestReplicationControllerNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken)
+	runTestInNamespace(t, "otherFakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorServiceAccountTokenNILAndNoName)
 }

--- a/cmd/runAsNonRoot.go
+++ b/cmd/runAsNonRoot.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 func checkRunAsNonRoot(container Container, result *Result) {
@@ -21,15 +23,13 @@ func checkRunAsNonRoot(container Container, result *Result) {
 	}
 }
 
-func auditRunAsNonRoot(items Items) (results []Result) {
-	for _, item := range items.Iter() {
-		containers, result := containerIter(item)
-		for _, container := range containers {
-			checkRunAsNonRoot(container, result)
-			if result != nil && len(result.Occurrences) > 0 {
-				results = append(results, *result)
-				break
-			}
+func auditRunAsNonRoot(resource k8sRuntime.Object) (results []Result) {
+	for _, container := range getContainers(resource) {
+		result := newResultFromResource(resource)
+		checkRunAsNonRoot(container, &result)
+		if len(result.Occurrences) > 0 {
+			results = append(results, result)
+			break
 		}
 	}
 	return

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 var path = "../fixtures/"
@@ -17,13 +18,13 @@ func runTest(t *testing.T, file string, function interface{}, errCode int, argSt
 	var image imgFlags
 	var limits limitFlags
 	switch function.(type) {
-	case (func(imgFlags, Items) []Result):
+	case (func(imgFlags, k8sRuntime.Object) []Result):
 		if len(argStr) != 1 {
 			log.Fatal("Incorrect number of images specified")
 		}
 		image = imgFlags{img: argStr[0]}
 		image.splitImageString()
-	case (func(limitFlags, Items) []Result):
+	case (func(limitFlags, k8sRuntime.Object) []Result):
 		if len(argStr) == 2 {
 			limits = limitFlags{cpuArg: argStr[0], memoryArg: argStr[1]}
 		} else if len(argStr) == 0 {
@@ -40,11 +41,11 @@ func runTest(t *testing.T, file string, function interface{}, errCode int, argSt
 	for _, resource := range resources {
 		var currentResults []Result
 		switch f := function.(type) {
-		case (func(Items) []Result):
+		case (func(k8sRuntime.Object) []Result):
 			currentResults = f(resource)
-		case (func(imgFlags, Items) []Result):
+		case (func(imgFlags, k8sRuntime.Object) []Result):
 			currentResults = f(image, resource)
-		case (func(limitFlags, Items) []Result):
+		case (func(limitFlags, k8sRuntime.Object) []Result):
 			currentResults = f(limits, resource)
 		default:
 			log.Fatal("Invalid function provided")
@@ -66,16 +67,8 @@ func runTest(t *testing.T, file string, function interface{}, errCode int, argSt
 	return
 }
 
-func runTestInNamespace(t *testing.T, namespace string, file string, function interface{}, errCode ...int) {
+func runTestInNamespace(t *testing.T, namespace string, file string, function interface{}, errCode int) {
 	rootConfig.namespace = namespace
-	var results = runTest(t, file, function, 0)
-	var errors []int
-	for _, result := range results {
-		for _, occurrence := range result.Occurrences {
-			errors = append(errors, occurrence.id)
-			assert.Contains(t, errCode, occurrence.id)
-		}
-	}
-	assert.Equal(t, len(errCode), len(errors))
+	runTest(t, file, function, errCode)
 	rootConfig.namespace = apiv1.NamespaceAll
 }


### PR DESCRIPTION
This is an attempt to switch away from all our internal types to `runtime.Objects`. Let me know what you think.