### PR TITLE
Add stricter check for audit tests

### DIFF
--- a/cmd/allowPrivilegeEscalation_test.go
+++ b/cmd/allowPrivilegeEscalation_test.go
@@ -5,21 +5,21 @@ import (
 )
 
 func TestSecurityContextNIL_APE(t *testing.T) {
-	runTest(t, "security_context_nil.yml", auditAllowPrivilegeEscalation, ErrorSecurityContextNIL)
+	runAuditTest(t, "security_context_nil.yml", auditAllowPrivilegeEscalation, []int{ErrorSecurityContextNIL})
 }
 
 func TestAllowPrivilegeEscalationNil(t *testing.T) {
-	runTest(t, "allow_privilege_escalation_nil.yml", auditAllowPrivilegeEscalation, ErrorAllowPrivilegeEscalationNIL)
+	runAuditTest(t, "allow_privilege_escalation_nil.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationNIL})
 }
 
 func TestAllowPrivilegeEscalationTrue(t *testing.T) {
-	runTest(t, "allow_privilege_escalation_true.yml", auditAllowPrivilegeEscalation, ErrorAllowPrivilegeEscalationTrue)
+	runAuditTest(t, "allow_privilege_escalation_true.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationTrue})
 }
 
 func TestAllowPrivilegeEscalationTrueAllowed(t *testing.T) {
-	runTest(t, "allow_privilege_escalation_true_allowed.yml", auditAllowPrivilegeEscalation, ErrorAllowPrivilegeEscalationTrueAllowed)
+	runAuditTest(t, "allow_privilege_escalation_true_allowed.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationTrueAllowed})
 }
 
 func TestAllowPrivilegeEscalationMisconfiguredAllow(t *testing.T) {
-	runTest(t, "allow_privilege_escalation_misconfigured_allow.yml", auditAllowPrivilegeEscalation, ErrorMisconfiguredKubeauditAllow)
+	runAuditTest(t, "allow_privilege_escalation_misconfigured_allow.yml", auditAllowPrivilegeEscalation, []int{ErrorMisconfiguredKubeauditAllow})
 }

--- a/cmd/automountServiceAccountToken_test.go
+++ b/cmd/automountServiceAccountToken_test.go
@@ -3,21 +3,21 @@ package cmd
 import "testing"
 
 func TestServiceAccountTokenDeprecated(t *testing.T) {
-	runTest(t, "service_account_token_deprecated.yml", auditAutomountServiceAccountToken, ErrorServiceAccountTokenDeprecated)
+	runAuditTest(t, "service_account_token_deprecated.yml", auditAutomountServiceAccountToken, []int{ErrorServiceAccountTokenDeprecated})
 }
 
 func TestServiceAccountTokenTrueAndNoName(t *testing.T) {
-	runTest(t, "service_account_token_true_and_no_name.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenTrueAndNoName)
+	runAuditTest(t, "service_account_token_true_and_no_name.yml", auditAutomountServiceAccountToken, []int{ErrorAutomountServiceAccountTokenTrueAndNoName})
 }
 
 func TestServiceAccountTokenNILAndNoName(t *testing.T) {
-	runTest(t, "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenNILAndNoName)
+	runAuditTest(t, "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, []int{ErrorAutomountServiceAccountTokenNILAndNoName})
 }
 
 func TestServiceAccountTokenTrueAllowed(t *testing.T) {
-	runTest(t, "service_account_token_true_allowed.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenTrueAllowed)
+	runAuditTest(t, "service_account_token_true_allowed.yml", auditAutomountServiceAccountToken, []int{ErrorAutomountServiceAccountTokenTrueAllowed})
 }
 
 func TestServiceAccountTokenMisconfiguredAllow(t *testing.T) {
-	runTest(t, "service_account_token_misconfigured_allow.yml", auditAutomountServiceAccountToken, ErrorMisconfiguredKubeauditAllow)
+	runAuditTest(t, "service_account_token_misconfigured_allow.yml", auditAutomountServiceAccountToken, []int{ErrorMisconfiguredKubeauditAllow})
 }

--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -14,25 +14,25 @@ func TestRecommendedCapabilitiesToBeDropped(t *testing.T) {
 }
 
 func TestSecurityContextNIL_SC(t *testing.T) {
-	runTest(t, "security_context_nil.yml", auditCapabilities, ErrorSecurityContextNIL)
+	runAuditTest(t, "security_context_nil.yml", auditCapabilities, []int{ErrorSecurityContextNIL})
 }
 
 func TestCapabilitiesNIL(t *testing.T) {
-	runTest(t, "capabilities_nil.yml", auditCapabilities, ErrorCapabilitiesNIL)
+	runAuditTest(t, "capabilities_nil.yml", auditCapabilities, []int{ErrorCapabilitiesNIL})
 }
 
 func TestCapabilitiesAdded(t *testing.T) {
-	runTest(t, "capabilities_added.yml", auditCapabilities, ErrorCapabilityAdded)
+	runAuditTest(t, "capabilities_added.yml", auditCapabilities, []int{ErrorCapabilityAdded})
 }
 
 func TestCapabilitiesSomeAllowed(t *testing.T) {
-	runTest(t, "capabilities_some_allowed.yml", auditCapabilities, ErrorCapabilityAllowed)
+	runAuditTest(t, "capabilities_some_allowed.yml", auditCapabilities, []int{ErrorCapabilityAllowed})
 }
 
 func TestCapabilitiesSomeDropped(t *testing.T) {
-	runTest(t, "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilityNotDropped)
+	runAuditTest(t, "capabilities_some_dropped.yml", auditCapabilities, []int{ErrorCapabilityNotDropped})
 }
 
 func TestCapabilitiesMisconfiguredAllow(t *testing.T) {
-	runTest(t, "capabilities_misconfigured_allow.yml", auditCapabilities, ErrorMisconfiguredKubeauditAllow)
+	runAuditTest(t, "capabilities_misconfigured_allow.yml", auditCapabilities, []int{ErrorMisconfiguredKubeauditAllow})
 }

--- a/cmd/image_test.go
+++ b/cmd/image_test.go
@@ -3,13 +3,13 @@ package cmd
 import "testing"
 
 func TestImageTagMissing(t *testing.T) {
-	runTest(t, "image_tag_missing.yml", auditImages, ErrorImageTagMissing, "fakeContainerImg:1.6")
+	runAuditTest(t, "image_tag_missing.yml", auditImages, []int{ErrorImageTagMissing}, "fakeContainerImg:1.6")
 }
 
 func TestImageTagIncorrect(t *testing.T) {
-	runTest(t, "image_tag_present.yml", auditImages, ErrorImageTagIncorrect, "fakeContainerImg:1.6")
+	runAuditTest(t, "image_tag_present.yml", auditImages, []int{ErrorImageTagIncorrect}, "fakeContainerImg:1.6")
 }
 
 func TestImageTagCorrect(t *testing.T) {
-	runTest(t, "image_tag_present.yml", auditImages, InfoImageCorrect, "fakeContainerImg:1.5")
+	runAuditTest(t, "image_tag_present.yml", auditImages, []int{InfoImageCorrect}, "fakeContainerImg:1.5")
 }

--- a/cmd/limits_test.go
+++ b/cmd/limits_test.go
@@ -3,20 +3,20 @@ package cmd
 import "testing"
 
 func TestResourcesLimitsNil(t *testing.T) {
-	runTest(t, "resources_limit_nil.yml", auditLimits, ErrorResourcesLimitsNIL)
+	runAuditTest(t, "resources_limit_nil.yml", auditLimits, []int{ErrorResourcesLimitsNIL})
 }
 
 func TestResourcesNoCPULimit(t *testing.T) {
-	runTest(t, "resources_limit_no_cpu.yml", auditLimits, ErrorResourcesLimitsCpuNIL)
+	runAuditTest(t, "resources_limit_no_cpu.yml", auditLimits, []int{ErrorResourcesLimitsCpuNIL})
 }
 
 func TestResourcesNoMemoryLimit(t *testing.T) {
-	runTest(t, "resources_limit_no_memory.yml", auditLimits, ErrorResourcesLimitsMemoryNIL)
+	runAuditTest(t, "resources_limit_no_memory.yml", auditLimits, []int{ErrorResourcesLimitsMemoryNIL})
 }
 func TestResourcesCPULimitExceeded(t *testing.T) {
-	runTest(t, "resources_limit.yml", auditLimits, ErrorResourcesLimitsCpuExceeded, "600m", "")
+	runAuditTest(t, "resources_limit.yml", auditLimits, []int{ErrorResourcesLimitsCpuExceeded}, "600m", "")
 }
 
 func TestResourcesMemoryLimitExceeded(t *testing.T) {
-	runTest(t, "resources_limit.yml", auditLimits, ErrorResourcesLimitsMemoryExceeded, "", "384")
+	runAuditTest(t, "resources_limit.yml", auditLimits, []int{ErrorResourcesLimitsMemoryExceeded}, "", "384")
 }

--- a/cmd/namespace_test.go
+++ b/cmd/namespace_test.go
@@ -5,33 +5,33 @@ import (
 )
 
 func TestDaemonSetInNamespace(t *testing.T) {
-	runTestInNamespace(t, "fakeDaemonSetPrivileged", "privileged_true.yml", auditPrivileged, ErrorPrivilegedTrue)
+	runAuditTestInNamespace(t, "fakeDaemonSetPrivileged", "privileged_true.yml", auditPrivileged, []int{ErrorPrivilegedTrue})
 }
 
 func TestDaemonSetNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeDaemonSetPrivileged", "privileged_true.yml", auditPrivileged, ErrorPrivilegedTrue)
+	runAuditTestInNamespace(t, "otherFakeDaemonSetPrivileged", "privileged_true.yml", auditPrivileged, []int{ErrorPrivilegedTrue})
 }
 
 func TestDeploymentInNamespace(t *testing.T) {
-	runTestInNamespace(t, "fakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilityNotDropped)
+	runAuditTestInNamespace(t, "fakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, []int{ErrorCapabilityNotDropped})
 }
 
 func TestDeploymentNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, ErrorCapabilityNotDropped)
+	runAuditTestInNamespace(t, "otherFakeDeploymentSC", "capabilities_some_dropped.yml", auditCapabilities, []int{ErrorCapabilityNotDropped})
 }
 
 func TestStatefulSetInNamespace(t *testing.T) {
-	runTestInNamespace(t, "fakeStatefulSetRORF", "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemNIL)
+	runAuditTestInNamespace(t, "fakeStatefulSetRORF", "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS, []int{ErrorReadOnlyRootFilesystemNIL})
 }
 
 func TestStatefulSetNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeStatefulSetRORF", "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemNIL)
+	runAuditTestInNamespace(t, "otherFakeStatefulSetRORF", "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS, []int{ErrorReadOnlyRootFilesystemNIL})
 }
 
 func TestReplicationControllerInNamespace(t *testing.T) {
-	runTestInNamespace(t, "fakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenNILAndNoName)
+	runAuditTestInNamespace(t, "fakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, []int{ErrorAutomountServiceAccountTokenNILAndNoName})
 }
 
 func TestReplicationControllerNotInNamespace(t *testing.T) {
-	runTestInNamespace(t, "otherFakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, ErrorAutomountServiceAccountTokenNILAndNoName)
+	runAuditTestInNamespace(t, "otherFakeReplicationControllerASAT", "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken, []int{ErrorAutomountServiceAccountTokenNILAndNoName})
 }

--- a/cmd/privileged_test.go
+++ b/cmd/privileged_test.go
@@ -3,21 +3,21 @@ package cmd
 import "testing"
 
 func TestSecurityContextNIL_Privileged(t *testing.T) {
-	runTest(t, "security_context_nil.yml", auditPrivileged, ErrorSecurityContextNIL)
+	runAuditTest(t, "security_context_nil.yml", auditPrivileged, []int{ErrorSecurityContextNIL})
 }
 
 func TestPrivilegedNIL(t *testing.T) {
-	runTest(t, "privileged_nil.yml", auditPrivileged, ErrorPrivilegedNIL)
+	runAuditTest(t, "privileged_nil.yml", auditPrivileged, []int{ErrorPrivilegedNIL})
 }
 
 func TestPrivilegedTrue(t *testing.T) {
-	runTest(t, "privileged_true.yml", auditPrivileged, ErrorPrivilegedTrue)
+	runAuditTest(t, "privileged_true.yml", auditPrivileged, []int{ErrorPrivilegedTrue})
 }
 
 func TestPrivilegedTrueAllowed(t *testing.T) {
-	runTest(t, "privileged_true_allowed.yml", auditPrivileged, ErrorPrivilegedTrueAllowed)
+	runAuditTest(t, "privileged_true_allowed.yml", auditPrivileged, []int{ErrorPrivilegedTrueAllowed})
 }
 
 func TestPrivilegedMisconfiguredAllow(t *testing.T) {
-	runTest(t, "privileged_misconfigured_allow.yml", auditPrivileged, ErrorMisconfiguredKubeauditAllow)
+	runAuditTest(t, "privileged_misconfigured_allow.yml", auditPrivileged, []int{ErrorMisconfiguredKubeauditAllow})
 }

--- a/cmd/readOnlyRootFilesystem_test.go
+++ b/cmd/readOnlyRootFilesystem_test.go
@@ -3,21 +3,21 @@ package cmd
 import "testing"
 
 func TestSecurityContextNIL_RORF(t *testing.T) {
-	runTest(t, "security_context_nil.yml", auditReadOnlyRootFS, ErrorSecurityContextNIL)
+	runAuditTest(t, "security_context_nil.yml", auditReadOnlyRootFS, []int{ErrorSecurityContextNIL})
 }
 
 func TestReadOnlyRootFilesystemNIL(t *testing.T) {
-	runTest(t, "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemNIL)
+	runAuditTest(t, "read_only_root_filesystem_nil.yml", auditReadOnlyRootFS, []int{ErrorReadOnlyRootFilesystemNIL})
 }
 
 func TestReadOnlyRootFilesystemFalse(t *testing.T) {
-	runTest(t, "read_only_root_filesystem_false.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemFalse)
+	runAuditTest(t, "read_only_root_filesystem_false.yml", auditReadOnlyRootFS, []int{ErrorReadOnlyRootFilesystemFalse})
 }
 
 func TestReadOnlyRootFilesystemFalseAllowed(t *testing.T) {
-	runTest(t, "read_only_root_filesystem_false_allowed.yml", auditReadOnlyRootFS, ErrorReadOnlyRootFilesystemFalseAllowed)
+	runAuditTest(t, "read_only_root_filesystem_false_allowed.yml", auditReadOnlyRootFS, []int{ErrorReadOnlyRootFilesystemFalseAllowed})
 }
 
 func TestReadOnlyRootFilesystemMisconfiguredAllow(t *testing.T) {
-	runTest(t, "read_only_root_filesystem_misconfigured_allow.yml", auditReadOnlyRootFS, ErrorMisconfiguredKubeauditAllow)
+	runAuditTest(t, "read_only_root_filesystem_misconfigured_allow.yml", auditReadOnlyRootFS, []int{ErrorMisconfiguredKubeauditAllow})
 }

--- a/cmd/runAsNonRoot_test.go
+++ b/cmd/runAsNonRoot_test.go
@@ -5,21 +5,21 @@ import (
 )
 
 func TestSecurityContextNIL(t *testing.T) {
-	runTest(t, "security_context_nil.yml", auditRunAsNonRoot, ErrorSecurityContextNIL)
+	runAuditTest(t, "security_context_nil.yml", auditRunAsNonRoot, []int{ErrorSecurityContextNIL})
 }
 
 func TestRunAsNonRootNil(t *testing.T) {
-	runTest(t, "run_as_non_root_nil.yml", auditRunAsNonRoot, ErrorRunAsNonRootNIL)
+	runAuditTest(t, "run_as_non_root_nil.yml", auditRunAsNonRoot, []int{ErrorRunAsNonRootNIL})
 }
 
 func TestRunAsNonRootFalse(t *testing.T) {
-	runTest(t, "run_as_non_root_false.yml", auditRunAsNonRoot, ErrorRunAsNonRootFalse)
+	runAuditTest(t, "run_as_non_root_false.yml", auditRunAsNonRoot, []int{ErrorRunAsNonRootFalse})
 }
 
 func TestAllowRunAsRootFalseAllowed(t *testing.T) {
-	runTest(t, "run_as_non_root_false_allowed.yml", auditRunAsNonRoot, ErrorRunAsNonRootFalseAllowed)
+	runAuditTest(t, "run_as_non_root_false_allowed.yml", auditRunAsNonRoot, []int{ErrorRunAsNonRootFalseAllowed})
 }
 
 func TestAllowRunAsNonRootMisconfiguredAllow(t *testing.T) {
-	runTest(t, "run_as_non_root_misconfigured_allow.yml", auditRunAsNonRoot, ErrorMisconfiguredKubeauditAllow)
+	runAuditTest(t, "run_as_non_root_misconfigured_allow.yml", auditRunAsNonRoot, []int{ErrorMisconfiguredKubeauditAllow})
 }

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -12,7 +12,7 @@ import (
 
 var path = "../fixtures/"
 
-func runTest(t *testing.T, file string, function interface{}, errCode int, argStr ...string) (results []Result) {
+func runAuditTest(t *testing.T, file string, function interface{}, errCodes []int, argStr ...string) (results []Result) {
 	assert := assert.New(t)
 	file = filepath.Join(path, file)
 	var image imgFlags
@@ -54,21 +54,22 @@ func runTest(t *testing.T, file string, function interface{}, errCode int, argSt
 			results = append(results, currentResult)
 		}
 	}
-	var errors []int
+	errors := map[int]bool{}
 	for _, result := range results {
 		for _, occurrence := range result.Occurrences {
-			errors = append(errors, occurrence.id)
+			errors[occurrence.id] = true
 		}
 	}
 
-	if errCode != 0 {
-		assert.Contains(errors, errCode)
+	for _, errCode := range errCodes {
+		assert.True(errors[errCode])
 	}
+	assert.Equal(len(errors), len(errCodes))
 	return
 }
 
-func runTestInNamespace(t *testing.T, namespace string, file string, function interface{}, errCode int) {
+func runAuditTestInNamespace(t *testing.T, namespace string, file string, function interface{}, errCodes []int) {
 	rootConfig.namespace = namespace
-	runTest(t, file, function, errCode)
+	runAuditTest(t, file, function, errCodes)
 	rootConfig.namespace = apiv1.NamespaceAll
 }


### PR DESCRIPTION
This PR enables our tests to ensure that only errors that were specified were thrown.