### PR TITLE
Automatically detect local/cluster mode

### DIFF
--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 	networking "k8s.io/api/networking/v1"
@@ -23,16 +22,6 @@ func kubeClientConfig(kubeconfig string) (*rest.Config, error) {
 }
 
 func kubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
-	if rootConfig.localMode {
-		kubeconfig = os.Getenv("HOME") + "/.kube/config"
-	}
-	if rootConfig.verbose == "DEBUG" {
-		log.SetLevel(log.DebugLevel)
-		log.AddHook(NewDebugHook())
-	}
-	if rootConfig.json {
-		log.SetFormatter(&log.JSONFormatter{})
-	}
 	config, err := kubeClientConfig(kubeconfig)
 	if err != nil {
 		log.Error(err)

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
+	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	networking "k8s.io/api/networking/v1"
@@ -13,18 +15,42 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func kubeClientConfig(kubeconfig string) (*rest.Config, error) {
-	if kubeconfig == "" && !rootConfig.localMode {
-		fmt.Println("Running inside cluster, using the cluster config")
-		return rest.InClusterConfig()
+// ErrNoReadableKubeConfig represents any error that prevents the client from opening a kubeconfig file.
+var ErrNoReadableKubeConfig = errors.New("unable to open kubeconfig file")
+
+func kubeClientConfig() (*rest.Config, error) {
+	if rootConfig.kubeConfig != "" {
+		return kubeClientConfigLocal()
 	}
-	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+
+	if config, err := rest.InClusterConfig(); err == nil {
+		log.Info("Running inside cluster, using the cluster config")
+		return config, nil
+	}
+
+	log.Info("Not running inside cluster, using local config")
+	home, ok := os.LookupEnv("HOME")
+	if !ok {
+		log.Error("Unable to load kubeconfig. No config file specified and $HOME not found.")
+		return nil, ErrNoReadableKubeConfig
+	}
+
+	rootConfig.kubeConfig = filepath.Join(home, ".kube", "config")
+	return kubeClientConfigLocal()
 }
 
-func kubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
-	config, err := kubeClientConfig(kubeconfig)
+func kubeClientConfigLocal() (*rest.Config, error) {
+	if _, err := os.Stat(rootConfig.kubeConfig); err != nil {
+		log.Errorf("Unable to load kubeconfig. Could not open file %s.", rootConfig.kubeConfig)
+		return nil, ErrNoReadableKubeConfig
+	}
+	return clientcmd.BuildConfigFromFlags("", rootConfig.kubeConfig)
+}
+
+func kubeClient() (*kubernetes.Clientset, error) {
+	config, err := kubeClientConfig()
 	if err != nil {
-		log.Error(err)
+		return nil, err
 	}
 	kube, err := kubernetes.NewForConfig(config)
 	return kube, err

--- a/cmd/networkPolicies.go
+++ b/cmd/networkPolicies.go
@@ -36,7 +36,7 @@ An ERROR log is given when a namespace does not have NetworkPolicy isolation
 Example usage:
 kubeaudit np`,
 	Run: func(cmd *cobra.Command, args []string) {
-		kube, err := kubeClient(rootConfig.kubeConfig)
+		kube, err := kubeClient()
 		if err != nil {
 			log.Error(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	apiv1 "k8s.io/api/core/v1"
 )
@@ -41,6 +42,7 @@ func Execute() {
 }
 
 func init() {
+	cobra.OnInitialize(processFlags)
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.kubeConfig, "kubeconfig", "c", "", "config file (default is $HOME/.kube/config")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.verbose, "verbose", "v", "INFO", "Set the debug level")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.localMode, "local", "l", false, "Local mode, uses ~/.kube/config as configuration")
@@ -49,4 +51,14 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.namespace, "namespace", "n", apiv1.NamespaceAll, "Specify the namespace scope to audit")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.manifest, "manifest", "f", "", "yaml configuration to audit")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.dropCapConfig, "dropCapConfig", "d", "", "yaml configuration to audit")
+}
+
+func processFlags() {
+	if rootConfig.verbose == "DEBUG" {
+		log.SetLevel(log.DebugLevel)
+		log.AddHook(NewDebugHook())
+	}
+	if rootConfig.json {
+		log.SetFormatter(&log.JSONFormatter{})
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -26,10 +27,7 @@ type rootFlags struct {
 var RootCmd = &cobra.Command{
 	Use:   "kubeaudit",
 	Short: "A Kubernetes security auditor",
-	Long: `kubeaudit is a program that will help you audit
-your Kubernetes clusters. Specify -l to run kubeaudit using ~/.kube/config
-otherwise it will attempt to create an in-cluster client.
-
+	Long: `kubeaudit is a program that checks security settings on your Kubernetes clusters.
 #patcheswelcome`,
 }
 
@@ -43,9 +41,10 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(processFlags)
-	RootCmd.PersistentFlags().StringVarP(&rootConfig.kubeConfig, "kubeconfig", "c", "", "config file (default is $HOME/.kube/config")
+	RootCmd.PersistentFlags().BoolVarP(&rootConfig.localMode, "local", "l", false, "[DEPRECATED] Local mode, uses $HOME/.kube/config as configuration")
+	RootCmd.Flags().MarkHidden("local")
+	RootCmd.PersistentFlags().StringVarP(&rootConfig.kubeConfig, "kubeconfig", "c", "", "Specify local config file (default is $HOME/.kube/config")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.verbose, "verbose", "v", "INFO", "Set the debug level")
-	RootCmd.PersistentFlags().BoolVarP(&rootConfig.localMode, "local", "l", false, "Local mode, uses ~/.kube/config as configuration")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.json, "json", "j", false, "Enable json logging")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.allPods, "allPods", "a", false, "Audit againsts pods in all the phases (default Running Phase)")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.namespace, "namespace", "n", apiv1.NamespaceAll, "Specify the namespace scope to audit")
@@ -60,5 +59,19 @@ func processFlags() {
 	}
 	if rootConfig.json {
 		log.SetFormatter(&log.JSONFormatter{})
+	}
+
+	if rootConfig.localMode == true {
+		log.Warn("-l/-local is deprecated! kubeaudit will default to local mode if it's not running in a cluster. ")
+		if rootConfig.kubeConfig != "" {
+			return
+		}
+
+		log.Warn("To use a local kubeconfig file from inside a cluster specify '-c $HOME/.kube/config'.")
+		home, ok := os.LookupEnv("HOME")
+		if !ok {
+			log.Fatal("Local mode selected but $HOME not set.")
+		}
+		rootConfig.kubeConfig = filepath.Join(home, ".kube", "config")
 	}
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -223,7 +223,7 @@ func getResources() (resources []k8sRuntime.Object, err error) {
 	if rootConfig.manifest != "" {
 		resources, err = getKubeResourcesManifest(rootConfig.manifest)
 	} else {
-		if kube, err := kubeClient(rootConfig.kubeConfig); err == nil {
+		if kube, err := kubeClient(); err == nil {
 			resources = getKubeResources(kube)
 		}
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/hashicorp/go-version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func init() {
@@ -28,15 +29,10 @@ var versionCmd = &cobra.Command{
 			"Version": ver,
 		}).Info("Kubeaudit")
 
-		kubeconfig := rootConfig.kubeConfig
-		if rootConfig.localMode {
-			kubeconfig = os.Getenv("HOME") + "/.kube/config"
-		}
-
-		kube, err := kubeClient(kubeconfig)
+		kube, err := kubeClient()
 		if err != nil {
-			log.Error(err)
-			os.Exit(1)
+			log.Warn("Could not get kubernetes server version.")
+			return
 		}
 		printKubernetesVersion(kube)
 	},


### PR DESCRIPTION
This changes the default behaviour of kubeaudit so that it will automatically use the default local config from `$HOME/.kube/config` any time it's not running within a k8s container. You can still force it to use local config mode if it is running in a cluster by specifying `-c/--kubeconfig /config/path`.

The `-l` flag is no longer necessary, but you can still use it and it will behave as before so it doesn't break backwards compatibility. It will display a warning if you use it.

I moved the logging initialization to root so that formatting and level will be respected for all commands even if you don't call kubeClient(). 

Edit: fixing the version number and adding tests will be done in a separate PR.