### PR TITLE
Cmd match example

### DIFF
--- a/cmd/automountServiceAccountToken.go
+++ b/cmd/automountServiceAccountToken.go
@@ -90,7 +90,7 @@ A WARN log is generated when a pod is found using Pod.Spec.DeprecatedServiceAcco
 Fix this by updating serviceAccount to serviceAccountName in your .yamls
 
 Example usage:
-kubeaudit rbac sat`,
+kubeaudit sat`,
 	Run: runAudit(auditAutomountServiceAccountToken),
 }
 

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -158,7 +159,19 @@ func auditCapabilities(resource k8sRuntime.Object) (results []Result) {
 var capabilitiesCmd = &cobra.Command{
 	Use:   "caps",
 	Short: "Audit container for capabilities",
-	Run:   runAudit(auditCapabilities),
+	Long: fmt.Sprintf(`This command determines which pods have capabilities which they should not according to
+the drop list. If no drop list is provided the following default is used:
+
+%s
+
+An ERROR log is generated when a pod has a capability which is on the drop list.
+
+A WARN log is generated when a pod has a capability allowed which is on the drop list.
+
+Example usage:
+kubeaudit caps
+kubeaudit caps -d drop.yml`, defaultDropCapConfig),
+	Run: runAudit(auditCapabilities),
 }
 
 func init() {

--- a/cmd/privileged.go
+++ b/cmd/privileged.go
@@ -74,7 +74,7 @@ A PASS is given when a container runs in a non-privileged mode
 A FAIL is generated when a container runs in a privileged mode
 
 Example usage:
-kubeaudit privileged`,
+kubeaudit priv`,
 	Run: runAudit(auditPrivileged),
 }
 

--- a/cmd/readOnlyRootFilesystem.go
+++ b/cmd/readOnlyRootFilesystem.go
@@ -75,7 +75,7 @@ A PASS is given when a container has a read only root filesystem
 A FAIL is given when a container does not have a read only root filesystem
 
 Example usage:
-kubeaudit runAsNonRoot`,
+kubeaudit rootfs`,
 	Run: runAudit(auditReadOnlyRootFS),
 }
 

--- a/cmd/runAsNonRoot.go
+++ b/cmd/runAsNonRoot.go
@@ -76,7 +76,7 @@ A PASS is given when a container runs as a uid greater than 0
 A FAIL is generated when a container runs as root
 
 Example usage:
-kubeaudit runAsNonRoot`,
+kubeaudit nonroot`,
 	Run: runAudit(auditRunAsNonRoot),
 }
 


### PR DESCRIPTION
Some of the command examples for cobra commands are different from the actual commands. This PR fixes the inconsistencies and also adds a description to the caps command, which didn't have one.