### PR TITLE
Psp apparmor seccomp

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -291,7 +291,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:33d20c896bdcb710d10b8629b87e3e9955ed3f9e82d11b9cce345115bc4bc0a4"
+  digest = "1:92cf230d2ac919398fb7edd06458b8d918bf9727d558dd4c31d24b85e2227075"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -324,7 +324,7 @@
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "b7d77fa220f5130ec63c2ca7167dd9653449c64d"
+  revision = "26c7a45db37856b19f05ba5aa21d2df4b81ecff3"
 
 [[projects]]
   branch = "master"

--- a/README.md
+++ b/README.md
@@ -309,6 +309,71 @@ WARN[0000] CPU limit exceeded, it is set to 1 but it must not exceed 500m. Pleas
 WARN[0000] Memory limit exceeded, it is set to 512Mi but it must not exceed 125Mi. Please adjust it!
 ```
 
+## Audit AppArmor
+
+It checks that AppArmor is enabled for all containers by making sure the following annotation exists on the pod. 
+There must be an annotation for each container in the pod:
+
+```
+container.apparmor.security.beta.kubernetes.io/<container name>: <profile>
+```
+
+where profile can be "runtime/default" or start with "localhost/" to be considered valid.
+
+If the AppArmor annotation is missing:
+
+```sh
+kubeaudit apparmor
+ERRO[0000] AppArmor annotation missing. Container=myContainer KubeType=pod Name=myPod Namespace=myNamespace
+```
+
+When AppArmor annotations are misconfigured:
+
+```sh
+kubeaudit apparmor
+ERRO[0000] AppArmor disabled. Annotation=container.apparmor.security.beta.kubernetes.io/myContainer
+  Container=myContainer KubeType=pod Name=myPod Namespace=myNamespace Reason=badval
+```
+
+## Audit Seccomp
+
+It checks that Seccomp is enabled for all containers by making sure one or both of the following annotations exists 
+on the pod. If no pod annotation is used, then there must be an annotation for each container. Container annotations 
+override the pod annotation:
+
+```
+# pod annotation
+seccomp.security.alpha.kubernetes.io/pod: <profile>
+
+# container annotation
+container.seccomp.security.alpha.kubernetes.io/<container name>: <profile>
+```
+
+where profile can be "runtime/default" or start with "localhost/" to be considered valid. "docker/default" is 
+deprecated and will show a warning. It should be replaced with "runtime/default".
+
+If the Seccomp annotation is missing:
+
+```sh
+kubeaudit seccomp
+ERRO[0000] Seccomp annotation missing. Container=myContainer KubeType=pod Name=myPod Namespace=myNamespace
+```
+
+When Seccomp annotations are misconfigured for a container:
+
+```sh
+kubeaudit seccomp
+ERRO[0000] Seccomp disabled for container. Annotation=container.seccomp.security.alpha.kubernetes.io/myContainer
+  Container=myContainer KubeType=pod Name=myPod Namespace=myNamespace Reason=badval
+```
+
+When Seccomp annotations are misconfigured for a pod:
+```sh
+kubeaudit seccomp
+ERRO[0000] Seccomp disabled for pod. Annotation=seccomp.security.alpha.kubernetes.io/pod Container= KubeType=pod
+  Name=myPod Namespace=myNamespace Reason=unconfined
+```
+
 <a name="labels" />
 
 ## Override Labels

--- a/cmd/all.go
+++ b/cmd/all.go
@@ -7,7 +7,7 @@ import (
 var allAuditFunctions = []interface{}{
 	auditAllowPrivilegeEscalation, auditReadOnlyRootFS, auditRunAsNonRoot,
 	auditAutomountServiceAccountToken, auditPrivileged, auditCapabilities,
-	auditLimits, auditImages,
+	auditLimits, auditImages, auditAppArmor, auditSeccomp,
 }
 
 var auditAllCmd = &cobra.Command{

--- a/cmd/all_test.go
+++ b/cmd/all_test.go
@@ -6,8 +6,9 @@ import (
 
 func TestAuditAll(t *testing.T) {
 	requiredErrors := []int{
-		ErrorAllowPrivilegeEscalationNil, ErrorAutomountServiceAccountTokenNilAndNoName, ErrorCapabilityNotDropped, ErrorImageTagMissing,
-		ErrorPrivilegedNil, ErrorReadOnlyRootFilesystemNil, ErrorResourcesLimitsNil, ErrorRunAsNonRootNil,
+		ErrorAllowPrivilegeEscalationNil, ErrorAutomountServiceAccountTokenNilAndNoName, ErrorCapabilityNotDropped,
+		ErrorImageTagMissing, ErrorPrivilegedNil, ErrorReadOnlyRootFilesystemNil, ErrorResourcesLimitsNil,
+		ErrorRunAsNonRootNil, ErrorAppArmorAnnotationMissing, ErrorSeccompAnnotationMissing,
 	}
 	runAuditTest(t, "audit_all.yml", mergeAuditFunctions(allAuditFunctions), requiredErrors)
 }

--- a/cmd/appArmor.go
+++ b/cmd/appArmor.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// As of Oct 1, 2018 these constants are not in the K8s API package, but once they are they should be replaced
+// https://github.com/kubernetes/kubernetes/blob/7f23a743e8c23ac6489340bbb34fa6f1d392db9d/pkg/security/apparmor/helpers.go#L25
+const (
+	// The prefix to an annotation key specifying a container profile.
+	ContainerAnnotationKeyPrefix = "container.apparmor.security.beta.kubernetes.io/"
+
+	// The profile specifying the runtime default.
+	ProfileRuntimeDefault = "runtime/default"
+	// The prefix for specifying profiles loaded on the node.
+	ProfileNamePrefix = "localhost/"
+)
+
+func checkAppArmor(resource k8sRuntime.Object, result *Result) {
+	annotations := getPodAnnotations(resource)
+
+	for _, container := range getContainers(resource) {
+		containerAnnotation := ContainerAnnotationKeyPrefix + container.Name
+		containerProfile, ok := annotations[containerAnnotation]
+
+		if !ok {
+			occ := Occurrence{
+				container: container.Name,
+				id:        ErrorAppArmorAnnotationMissing,
+				kind:      Error,
+				message:   fmt.Sprintf("AppArmor annotation missing."),
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+			continue
+		}
+
+		if badAppArmorProfileName(containerProfile) {
+			occ := Occurrence{
+				container: container.Name,
+				id:        ErrorAppArmorDisabled,
+				kind:      Error,
+				message:   fmt.Sprintf("AppArmor disabled."),
+				metadata: Metadata{
+					"Annotation": containerAnnotation,
+					"Reason":     prettifyReason(containerProfile),
+				},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		}
+	}
+}
+
+func badAppArmorProfileName(profileName string) bool {
+	return profileName != ProfileRuntimeDefault && !strings.HasPrefix(profileName, ProfileNamePrefix)
+}
+
+func auditAppArmor(resource k8sRuntime.Object) (results []Result) {
+	result, err := newResultFromResource(resource)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	checkAppArmor(resource, result)
+
+	if len(result.Occurrences) > 0 {
+		results = append(results, *result)
+	}
+
+	return
+}
+
+var appArmor = &cobra.Command{
+	Use:   "apparmor",
+	Short: "Audit containers running without AppArmor",
+	Long: `This command determines which containers in a kubernetes cluster
+are running without AppArmor enabled.
+
+A PASS is given when all containers have AppArmor enabled.
+A FAIL is generated when a container has AppArmor disabled or misconfigured.
+
+Example usage:
+kubeaudit apparmor`,
+	Run: runAudit(auditAppArmor),
+}
+
+func init() {
+	RootCmd.AddCommand(appArmor)
+}

--- a/cmd/appArmor_fixes.go
+++ b/cmd/appArmor_fixes.go
@@ -1,0 +1,20 @@
+package cmd
+
+import k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+
+func fixAppArmor(resource k8sRuntime.Object) k8sRuntime.Object {
+	annotations := getPodAnnotations(resource)
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	for _, container := range getContainers(resource) {
+		containerAnnotation := ContainerAnnotationKeyPrefix + container.Name
+		if val, ok := annotations[containerAnnotation]; !ok || badAppArmorProfileName(val) {
+			annotations[containerAnnotation] = ProfileRuntimeDefault
+		}
+	}
+
+	return setPodAnnotations(resource, annotations)
+}

--- a/cmd/appArmor_fixes_test.go
+++ b/cmd/appArmor_fixes_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import "testing"
+
+func TestFixAppArmorDisabled(t *testing.T) {
+	testFixAppArmor(t, "apparmor_disabled.yml")
+}
+
+func TestFixAppArmorAnnotationMissing(t *testing.T) {
+	testFixAppArmor(t, "apparmor_annotation_missing.yml")
+}
+
+func testFixAppArmor(t *testing.T, configFile string) {
+	assert, resource := FixTestSetup(t, configFile, auditAppArmor)
+	containers := getContainers(resource)
+	annotations := getPodAnnotations(resource)
+
+	for _, container := range containers {
+		containerAnnotation := ContainerAnnotationKeyPrefix + container.Name
+		assert.Equal(ProfileRuntimeDefault, annotations[containerAnnotation])
+	}
+}

--- a/cmd/appArmor_test.go
+++ b/cmd/appArmor_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestAppArmorEnabled(t *testing.T) {
+	runAuditTest(t, "apparmor_enabled.yml", auditAppArmor, []int{})
+}
+
+func TestAppArmorAnnotationMissing(t *testing.T) {
+	runAuditTest(t, "apparmor_annotation_missing.yml", auditAppArmor, []int{ErrorAppArmorAnnotationMissing})
+}
+
+func TestAppArmorBadValue(t *testing.T) {
+	runAuditTest(t, "apparmor_disabled.yml", auditAppArmor, []int{ErrorAppArmorDisabled})
+}

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -65,6 +65,20 @@ const (
 	// ErrorServiceAccountTokenDeprecated occurs when serviceAccount is used. ServiceAccount is a deprecated alias
 	// for ServiceAccountName.
 	ErrorServiceAccountTokenDeprecated
+	// ErrorAppArmorDisabled occurs when the AppArmor annotation is set to a bad value.
+	ErrorAppArmorDisabled
+	// ErrorAppArmorAnnotationMissing occurs when there is no annotation enabling AppArmor on the pod.
+	ErrorAppArmorAnnotationMissing
+	// ErrorSeccompDisabledPod occurs when the Seccomp annotation is set to a bad value.
+	ErrorSeccompDisabledPod
+	// ErrorSeccompDisabled occurs when the Seccomp annotation is set to a bad value.
+	ErrorSeccompDisabled
+	// ErrorSeccompAnnotationMissing occurs when there is no annotation enabling Seccomp on the pod.
+	ErrorSeccompAnnotationMissing
+	// ErrorSeccompDeprecatedPod occurs when the Seccomp annotation is set to a deprecated value.
+	ErrorSeccompDeprecatedPod
+	// ErrorSeccompDeprecated occurs when the Seccomp annotation is set to a deprecated value.
+	ErrorSeccompDeprecated
 	// InfoImageCorrect occurs when an image tag is correct.
 	InfoImageCorrect
 )

--- a/cmd/k8sruntime_util.go
+++ b/cmd/k8sruntime_util.go
@@ -105,6 +105,36 @@ func setASAT(resource k8sRuntime.Object, b bool) k8sRuntime.Object {
 	return resource
 }
 
+func setPodAnnotations(resource k8sRuntime.Object, annotations map[string]string) k8sRuntime.Object {
+	switch kubeType := resource.(type) {
+	case *CronJob:
+		kubeType.Spec.JobTemplate.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *DaemonSet:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *DeploymentV1Beta1:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *DeploymentV1Beta2:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *DeploymentExtensionsV1Beta1:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *Pod:
+		kubeType.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *ReplicationController:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *StatefulSet:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	}
+	return resource
+}
+
 func getContainers(resource k8sRuntime.Object) (container []Container) {
 	switch kubeType := resource.(type) {
 	case *CronJob:
@@ -125,6 +155,28 @@ func getContainers(resource k8sRuntime.Object) (container []Container) {
 		container = kubeType.Spec.Template.Spec.Containers
 	}
 	return container
+}
+
+func getPodAnnotations(resource k8sRuntime.Object) (annotations map[string]string) {
+	switch kubeType := resource.(type) {
+	case *CronJob:
+		annotations = kubeType.Spec.JobTemplate.Spec.Template.ObjectMeta.GetAnnotations()
+	case *DaemonSet:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *DeploymentV1Beta1:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *DeploymentV1Beta2:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *DeploymentExtensionsV1Beta1:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *Pod:
+		annotations = kubeType.ObjectMeta.GetAnnotations()
+	case *ReplicationController:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *StatefulSet:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	}
+	return
 }
 
 // WriteToFile writes and then appends incoming resource

--- a/cmd/result.go
+++ b/cmd/result.go
@@ -58,6 +58,7 @@ func createFields(res Result, occ Occurrence) (fields log.Fields) {
 	for k, v := range occ.metadata {
 		fields[k] = v
 	}
+	fields["Container"] = occ.container
 	return
 }
 

--- a/cmd/seccomp.go
+++ b/cmd/seccomp.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	apiv1 "k8s.io/api/core/v1"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+func checkSeccomp(resource k8sRuntime.Object, result *Result) {
+	annotations := getPodAnnotations(resource)
+	podAnnotation := apiv1.SeccompPodAnnotationKey
+	podProfile, podOk := annotations[podAnnotation]
+
+	if podOk {
+		if badSeccompProfileName(podProfile) {
+			occ := Occurrence{
+				container: "",
+				id:        ErrorSeccompDisabledPod,
+				kind:      Error,
+				message:   fmt.Sprintf("Seccomp disabled for pod."),
+				metadata: Metadata{
+					"Annotation": podAnnotation,
+					"Reason":     prettifyReason(podProfile),
+				},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+			return
+		}
+
+		if podProfile == apiv1.DeprecatedSeccompProfileDockerDefault {
+			occ := Occurrence{
+				container: "",
+				id:        ErrorSeccompDeprecatedPod,
+				kind:      Warn,
+				message:   fmt.Sprintf("Seccomp annotation for pod set to a deprecated value."),
+				metadata: Metadata{
+					"Annotation": podAnnotation,
+					"Reason":     prettifyReason(podProfile),
+				},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		}
+	}
+
+	for _, container := range getContainers(resource) {
+		containerAnnotation := apiv1.SeccompContainerAnnotationKeyPrefix + container.Name
+		containerProfile, containerOk := annotations[containerAnnotation]
+
+		if !containerOk && !podOk {
+			occ := Occurrence{
+				container: container.Name,
+				id:        ErrorSeccompAnnotationMissing,
+				kind:      Error,
+				message:   fmt.Sprintf("Seccomp annotation missing."),
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+			continue
+		}
+
+		if containerOk && badSeccompProfileName(containerProfile) {
+			occ := Occurrence{
+				container: container.Name,
+				id:        ErrorSeccompDisabled,
+				kind:      Error,
+				message:   fmt.Sprintf("Seccomp disabled for container."),
+				metadata: Metadata{
+					"Annotation": containerAnnotation,
+					"Reason":     prettifyReason(containerProfile),
+				},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+			continue
+		}
+
+		if containerOk && containerProfile == apiv1.DeprecatedSeccompProfileDockerDefault {
+			occ := Occurrence{
+				container: container.Name,
+				id:        ErrorSeccompDeprecated,
+				kind:      Warn,
+				message:   fmt.Sprintf("Seccomp annotation for container set to a deprecated value."),
+				metadata: Metadata{
+					"Annotation": containerAnnotation,
+					"Reason":     prettifyReason(containerProfile),
+				},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		}
+	}
+}
+
+func badSeccompProfileName(profileName string) bool {
+	switch {
+	case profileName == apiv1.SeccompProfileRuntimeDefault:
+		return false
+	case profileName == apiv1.DeprecatedSeccompProfileDockerDefault:
+		return false
+	case strings.HasPrefix(profileName, ProfileNamePrefix):
+		return false
+	default:
+		return true
+	}
+}
+
+func auditSeccomp(resource k8sRuntime.Object) (results []Result) {
+	result, err := newResultFromResource(resource)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	checkSeccomp(resource, result)
+
+	if len(result.Occurrences) > 0 {
+		results = append(results, *result)
+	}
+
+	return
+}
+
+var seccomp = &cobra.Command{
+	Use:   "seccomp",
+	Short: "Audit containers running without Seccomp",
+	Long: `This command determines which containers in a kubernetes cluster
+are running without Seccomp enabled.
+
+A PASS is given when all containers have Seccomp enabled.
+A FAIL is generated when a container has Seccomp disabled or misconfigured.
+
+Example usage:
+kubeaudit seccomp`,
+	Run: runAudit(auditSeccomp),
+}
+
+func init() {
+	RootCmd.AddCommand(seccomp)
+}

--- a/cmd/seccomp_fixes.go
+++ b/cmd/seccomp_fixes.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+)
+
+func fixSeccomp(resource k8sRuntime.Object) k8sRuntime.Object {
+	annotations := getPodAnnotations(resource)
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	podAnnotation := apiv1.SeccompPodAnnotationKey
+	podProfile, podOk := annotations[podAnnotation]
+	podValid := podOk && !badSeccompProfileName(podProfile)
+
+	// If there is no pod annotation or it is set to a bad value, set it to the default profile.
+	if !podValid {
+		annotations[podAnnotation] = apiv1.SeccompProfileRuntimeDefault
+	}
+
+	// If container annotation is set to invalid profile and
+	// 1. pod annotation is set to default profile, then remove container annotation
+	// 2. pod annotation is not set to default profile, then set container annotation to default
+	for _, container := range getContainers(resource) {
+		containerAnnotation := apiv1.SeccompContainerAnnotationKeyPrefix + container.Name
+		containerProfile, containerOk := annotations[containerAnnotation]
+
+		if containerOk && badSeccompProfileName(containerProfile) {
+			if podValid && podProfile == apiv1.SeccompProfileRuntimeDefault {
+				delete(annotations, containerAnnotation)
+			} else {
+				annotations[containerAnnotation] = apiv1.SeccompProfileRuntimeDefault
+			}
+		}
+	}
+
+	return setPodAnnotations(resource, annotations)
+}

--- a/cmd/seccomp_fixes_test.go
+++ b/cmd/seccomp_fixes_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestFixSeccompDisabled(t *testing.T) {
+	fileToFix := "seccomp_disabled.yml"
+	fileFixed := "seccomp_disabled-fixed.yml"
+	assertEqualYaml(fileToFix, fileFixed, auditSeccomp, t)
+}
+
+func TestFixSeccompDisabled2(t *testing.T) {
+	fileToFix := "seccomp_disabled_2.yml"
+	fileFixed := "seccomp_disabled_2-fixed.yml"
+	assertEqualYaml(fileToFix, fileFixed, auditSeccomp, t)
+}
+
+func TestFixSeccompDisabledPod(t *testing.T) {
+	testFixSeccomp(t, "seccomp_disabled_pod.yml")
+}
+
+func TestFixSeccompAnnotationMissing(t *testing.T) {
+	testFixSeccomp(t, "seccomp_annotation_missing.yml")
+}
+
+func testFixSeccomp(t *testing.T, configFile string) {
+	assert, resource := FixTestSetup(t, configFile, auditSeccomp)
+	annotations := getPodAnnotations(resource)
+	podVal, podOk := annotations[apiv1.SeccompPodAnnotationKey]
+
+	assert.True(podOk)
+	assert.False(badSeccompProfileName(podVal))
+
+	for _, container := range getContainers(resource) {
+		containerAnnotation := apiv1.SeccompContainerAnnotationKeyPrefix + container.Name
+		if val, ok := annotations[containerAnnotation]; ok {
+			assert.False(badSeccompProfileName(val))
+		}
+	}
+}

--- a/cmd/seccomp_test.go
+++ b/cmd/seccomp_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestSeccompEnabledPod(t *testing.T) {
+	runAuditTest(t, "seccomp_enabled_pod.yml", auditSeccomp, []int{})
+}
+
+func TestSeccompEnabled(t *testing.T) {
+	runAuditTest(t, "seccomp_enabled.yml", auditSeccomp, []int{})
+}
+
+func TestSeccompAnnotationMissing(t *testing.T) {
+	runAuditTest(t, "seccomp_annotation_missing.yml", auditSeccomp, []int{ErrorSeccompAnnotationMissing})
+}
+
+func TestSeccompBadValuePod(t *testing.T) {
+	runAuditTest(t, "seccomp_disabled_pod.yml", auditSeccomp, []int{ErrorSeccompDisabledPod})
+}
+
+func TestSeccompBadValue(t *testing.T) {
+	runAuditTest(t, "seccomp_disabled.yml", auditSeccomp, []int{ErrorSeccompDisabled})
+}
+
+func TestSeccompDeprecatedValuePod(t *testing.T) {
+	runAuditTest(t, "seccomp_deprecated_pod.yml", auditSeccomp, []int{ErrorSeccompDeprecatedPod})
+}
+
+func TestSeccompDeprecatedValue(t *testing.T) {
+	runAuditTest(t, "seccomp_deprecated.yml", auditSeccomp, []int{ErrorSeccompDeprecated})
+}

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -105,3 +105,11 @@ func NewPod() *Pod {
 	}
 	return nil
 }
+
+func assertEqualYaml(fileToFix string, fileFixed string, auditFunc func(resource k8sRuntime.Object) []Result, t *testing.T) {
+	assert, fixedResource := FixTestSetup(t, fileToFix, auditFunc)
+	fileFixed = filepath.Join(path, fileFixed)
+	correctlyFixedResources, err := getKubeResourcesManifest(fileFixed)
+	assert.Nil(err)
+	assert.Equal(correctlyFixedResources[0], fixedResource)
+}

--- a/fixtures/apparmor_annotation_missing.yml
+++ b/fixtures/apparmor_annotation_missing.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodAA
+    namespace: PodNamespaceAA
+spec:
+    containers:
+    - name: AAcontainer

--- a/fixtures/apparmor_disabled.yml
+++ b/fixtures/apparmor_disabled.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodAA
+    namespace: PodNamespaceAA
+    annotations:
+      container.apparmor.security.beta.kubernetes.io/containerAA: badval
+spec:
+    containers:
+    - name: containerAA

--- a/fixtures/apparmor_enabled.yml
+++ b/fixtures/apparmor_enabled.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodAA
+    namespace: PodNamespaceAA
+    annotations:
+      container.apparmor.security.beta.kubernetes.io/AAcontainer: localhost/something
+spec:
+    containers:
+    - name: AAcontainer

--- a/fixtures/autofix-fixed.yml
+++ b/fixtures/autofix-fixed.yml
@@ -11,6 +11,10 @@ spec:
       creationTimestamp: null
       labels:
         apps: fakeSecurityContext
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        container.apparmor.security.beta.kubernetes.io/fakeContainerSC1: runtime/default
+        container.apparmor.security.beta.kubernetes.io/fakeContainerSC2: runtime/default
     spec:
       automountServiceAccountToken: false
       containers:

--- a/fixtures/cronjob-fixed.yml
+++ b/fixtures/cronjob-fixed.yml
@@ -6,6 +6,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            seccomp.security.alpha.kubernetes.io/pod: runtime/default
+            container.apparmor.security.beta.kubernetes.io/hello: runtime/default
         spec:
           automountServiceAccountToken: false
           containers:

--- a/fixtures/seccomp_annotation_missing.yml
+++ b/fixtures/seccomp_annotation_missing.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodS
+    namespace: PodNamespaceS
+spec:
+    containers:
+    - name: containerS

--- a/fixtures/seccomp_deprecated.yml
+++ b/fixtures/seccomp_deprecated.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodAA
+    namespace: PodNamespaceS
+    annotations:
+        container.seccomp.security.alpha.kubernetes.io/containerS: docker/default
+spec:
+    containers:
+    - name: containerS

--- a/fixtures/seccomp_deprecated_pod.yml
+++ b/fixtures/seccomp_deprecated_pod.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodAA
+    namespace: PodNamespaceS
+    annotations:
+        seccomp.security.alpha.kubernetes.io/pod: docker/default
+        container.seccomp.security.alpha.kubernetes.io/containerS: localhost/bla
+spec:
+    containers:
+    - name: containerS

--- a/fixtures/seccomp_disabled-fixed.yml
+++ b/fixtures/seccomp_disabled-fixed.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodS
+    namespace: PodNamespaceS
+    annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+spec:
+    containers:
+    - name: containerS
+    - name: containerS2
+    - name: containerS3

--- a/fixtures/seccomp_disabled.yml
+++ b/fixtures/seccomp_disabled.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodS
+    namespace: PodNamespaceS
+    annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        container.seccomp.security.alpha.kubernetes.io/containerS: badval
+        container.seccomp.security.alpha.kubernetes.io/containerS2: unconfined
+spec:
+    containers:
+    - name: containerS
+    - name: containerS2
+    - name: containerS3

--- a/fixtures/seccomp_disabled_2-fixed.yml
+++ b/fixtures/seccomp_disabled_2-fixed.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodS
+    namespace: PodNamespaceS
+    annotations:
+        seccomp.security.alpha.kubernetes.io/pod: localhost/bla
+        container.seccomp.security.alpha.kubernetes.io/containerS: runtime/default
+spec:
+    containers:
+    - name: containerS

--- a/fixtures/seccomp_disabled_2.yml
+++ b/fixtures/seccomp_disabled_2.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodS
+    namespace: PodNamespaceS
+    annotations:
+        seccomp.security.alpha.kubernetes.io/pod: localhost/bla
+        container.seccomp.security.alpha.kubernetes.io/containerS: badval
+spec:
+    containers:
+    - name: containerS

--- a/fixtures/seccomp_disabled_pod.yml
+++ b/fixtures/seccomp_disabled_pod.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodS
+    namespace: PodNamespaceS
+    annotations:
+        seccomp.security.alpha.kubernetes.io/pod: unconfined
+        container.seccomp.security.alpha.kubernetes.io/containerS: runtime/default
+spec:
+    containers:
+    - name: containerS

--- a/fixtures/seccomp_enabled.yml
+++ b/fixtures/seccomp_enabled.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodAA
+    namespace: PodNamespaceS
+    annotations:
+        container.seccomp.security.alpha.kubernetes.io/containerS: runtime/default
+spec:
+    containers:
+    - name: containerS

--- a/fixtures/seccomp_enabled_pod.yml
+++ b/fixtures/seccomp_enabled_pod.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: PodAA
+    namespace: PodNamespaceS
+    annotations:
+        seccomp.security.alpha.kubernetes.io/pod: localhost/bla
+spec:
+    containers:
+    - name: containerS


### PR DESCRIPTION
Fixes #95 

This PR adds auditing and fixing for AppArmor and Seccomp by checking for relevant pod annotations. 

## AppArmor

It checks that AppArmor is enabled for all containers by making sure the following annotation exists on the pod.  There must be an annotation for each container in the pod:

```
container.apparmor.security.beta.kubernetes.io/<container name>: <profile>
```

where profile can be "runtime/default" or start with "localhost/" to be considered valid.

## Seccomp

It checks that Seccomp is enabled for all containers by making sure one or both of the following annotations exists on the pod. If no pod annotation is used, then there must be an annotation for each container. Container annotations override the pod annotation:

## PSP

AppArmor and Seccomp can also be enabled using PSPs but as kubeaudit does not support PSPs for other issues which can also be controlled using PSPs, and it would be a large change, I have created a separate issue for it: #123.