### PR TITLE
Add support for apps v1

### DIFF
--- a/cmd/all_test.go
+++ b/cmd/all_test.go
@@ -12,3 +12,12 @@ func TestAuditAll(t *testing.T) {
 	}
 	runAuditTest(t, "audit_all.yml", mergeAuditFunctions(allAuditFunctions), requiredErrors)
 }
+
+func TestAuditAllV1BETA1(t *testing.T) {
+	requiredErrors := []int{
+		ErrorAllowPrivilegeEscalationNil, ErrorAutomountServiceAccountTokenNilAndNoName, ErrorCapabilityNotDropped,
+		ErrorImageTagMissing, ErrorPrivilegedNil, ErrorReadOnlyRootFilesystemNil, ErrorResourcesLimitsNil,
+		ErrorRunAsNonRootNil, ErrorAppArmorAnnotationMissing, ErrorSeccompAnnotationMissing,
+	}
+	runAuditTest(t, "audit_all_v1beta1.yml", mergeAuditFunctions(allAuditFunctions), requiredErrors)
+}

--- a/cmd/all_test.go
+++ b/cmd/all_test.go
@@ -13,7 +13,7 @@ func TestAuditAll(t *testing.T) {
 	runAuditTest(t, "audit_all.yml", mergeAuditFunctions(allAuditFunctions), requiredErrors)
 }
 
-func TestAuditAllV1BETA1(t *testing.T) {
+func TestAuditAllV1beta1(t *testing.T) {
 	requiredErrors := []int{
 		ErrorAllowPrivilegeEscalationNil, ErrorAutomountServiceAccountTokenNilAndNoName, ErrorCapabilityNotDropped,
 		ErrorImageTagMissing, ErrorPrivilegedNil, ErrorReadOnlyRootFilesystemNil, ErrorResourcesLimitsNil,

--- a/cmd/allowPrivilegeEscalation_test.go
+++ b/cmd/allowPrivilegeEscalation_test.go
@@ -23,3 +23,23 @@ func TestAllowPrivilegeEscalationTrueAllowed(t *testing.T) {
 func TestAllowPrivilegeEscalationMisconfiguredAllow(t *testing.T) {
 	runAuditTest(t, "allow_privilege_escalation_misconfigured_allow.yml", auditAllowPrivilegeEscalation, []int{ErrorMisconfiguredKubeauditAllow})
 }
+
+func TestSecurityContextNil_APEV1BETA1(t *testing.T) {
+	runAuditTest(t, "security_context_nil_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationNil})
+}
+
+func TestAllowPrivilegeEscalationNilV1BETA1(t *testing.T) {
+	runAuditTest(t, "allow_privilege_escalation_nil_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationNil})
+}
+
+func TestAllowPrivilegeEscalationTrueV1BETA1(t *testing.T) {
+	runAuditTest(t, "allow_privilege_escalation_true_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationTrue})
+}
+
+func TestAllowPrivilegeEscalationTrueAllowedV1BETA1(t *testing.T) {
+	runAuditTest(t, "allow_privilege_escalation_true_allowed_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationTrueAllowed})
+}
+
+func TestAllowPrivilegeEscalationMisconfiguredAllowV1BETA1(t *testing.T) {
+	runAuditTest(t, "allow_privilege_escalation_misconfigured_allow_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorMisconfiguredKubeauditAllow})
+}

--- a/cmd/allowPrivilegeEscalation_test.go
+++ b/cmd/allowPrivilegeEscalation_test.go
@@ -24,22 +24,22 @@ func TestAllowPrivilegeEscalationMisconfiguredAllow(t *testing.T) {
 	runAuditTest(t, "allow_privilege_escalation_misconfigured_allow.yml", auditAllowPrivilegeEscalation, []int{ErrorMisconfiguredKubeauditAllow})
 }
 
-func TestSecurityContextNil_APEV1BETA1(t *testing.T) {
+func TestSecurityContextNil_APEV1Beta1(t *testing.T) {
 	runAuditTest(t, "security_context_nil_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationNil})
 }
 
-func TestAllowPrivilegeEscalationNilV1BETA1(t *testing.T) {
+func TestAllowPrivilegeEscalationNilV1Beta1(t *testing.T) {
 	runAuditTest(t, "allow_privilege_escalation_nil_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationNil})
 }
 
-func TestAllowPrivilegeEscalationTrueV1BETA1(t *testing.T) {
+func TestAllowPrivilegeEscalationTrueV1Beta1(t *testing.T) {
 	runAuditTest(t, "allow_privilege_escalation_true_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationTrue})
 }
 
-func TestAllowPrivilegeEscalationTrueAllowedV1BETA1(t *testing.T) {
+func TestAllowPrivilegeEscalationTrueAllowedV1Beta1(t *testing.T) {
 	runAuditTest(t, "allow_privilege_escalation_true_allowed_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorAllowPrivilegeEscalationTrueAllowed})
 }
 
-func TestAllowPrivilegeEscalationMisconfiguredAllowV1BETA1(t *testing.T) {
+func TestAllowPrivilegeEscalationMisconfiguredAllowV1Beta1(t *testing.T) {
 	runAuditTest(t, "allow_privilege_escalation_misconfigured_allow_v1beta1.yml", auditAllowPrivilegeEscalation, []int{ErrorMisconfiguredKubeauditAllow})
 }

--- a/cmd/autofix_test.go
+++ b/cmd/autofix_test.go
@@ -19,3 +19,15 @@ func TestFix(t *testing.T) {
 	assert.Nil(err)
 	assert.Nil(deep.Equal(correctlyFixedResources, fixedResources))
 }
+
+func TestFixV1Beta1(t *testing.T) {
+	file := "../fixtures/autofix_v1beta1.yml"
+	fileFixed := "../fixtures/autofix-fixed_v1beta1.yml"
+	assert := assert.New(t)
+	resources, err := getKubeResourcesManifest(file)
+	assert.Nil(err)
+	fixedResources := fix(resources)
+	correctlyFixedResources, err := getKubeResourcesManifest(fileFixed)
+	assert.Nil(err)
+	assert.Nil(deep.Equal(correctlyFixedResources, fixedResources))
+}

--- a/cmd/k8sruntime_util.go
+++ b/cmd/k8sruntime_util.go
@@ -17,10 +17,16 @@ func setContainers(resource k8sRuntime.Object, containers []Container) k8sRuntim
 	case *DaemonSet:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
+	case *DaemonSetV1:
+		t.Spec.Template.Spec.Containers = containers
+		return t.DeepCopyObject()
 	case *DeploymentV1Beta1:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
 	case *DeploymentV1Beta2:
+		t.Spec.Template.Spec.Containers = containers
+		return t.DeepCopyObject()
+	case *DeploymentV1:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
 	case *DeploymentExtensionsV1Beta1:
@@ -35,6 +41,9 @@ func setContainers(resource k8sRuntime.Object, containers []Container) k8sRuntim
 	case *StatefulSet:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
+	case *StatefulSetV1:
+		t.Spec.Template.Spec.Containers = containers
+		return t.DeepCopyObject()
 	}
 	return resource
 }
@@ -47,10 +56,16 @@ func disableDSA(resource k8sRuntime.Object) k8sRuntime.Object {
 	case *DaemonSet:
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
+	case *DaemonSetV1:
+		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
+		return t.DeepCopyObject()
 	case *DeploymentV1Beta1:
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DeploymentV1Beta2:
+		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
+		return t.DeepCopyObject()
+	case *DeploymentV1:
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DeploymentExtensionsV1Beta1:
@@ -63,6 +78,9 @@ func disableDSA(resource k8sRuntime.Object) k8sRuntime.Object {
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *StatefulSet:
+		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
+		return t.DeepCopyObject()
+	case *StatefulSetV1:
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	}
@@ -83,10 +101,16 @@ func setASAT(resource k8sRuntime.Object, b bool) k8sRuntime.Object {
 	case *DaemonSet:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
+	case *DaemonSetV1:
+		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
+		return t.DeepCopyObject()
 	case *DeploymentV1Beta1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
 	case *DeploymentV1Beta2:
+		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
+		return t.DeepCopyObject()
+	case *DeploymentV1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
 	case *DeploymentExtensionsV1Beta1:
@@ -99,6 +123,9 @@ func setASAT(resource k8sRuntime.Object, b bool) k8sRuntime.Object {
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
 	case *StatefulSet:
+		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
+		return t.DeepCopyObject()
+	case *StatefulSetV1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
 	}
@@ -141,9 +168,13 @@ func getContainers(resource k8sRuntime.Object) (container []Container) {
 		container = kubeType.Spec.JobTemplate.Spec.Template.Spec.Containers
 	case *DaemonSet:
 		container = kubeType.Spec.Template.Spec.Containers
+	case *DaemonSetV1:
+		container = kubeType.Spec.Template.Spec.Containers
 	case *DeploymentV1Beta1:
 		container = kubeType.Spec.Template.Spec.Containers
 	case *DeploymentV1Beta2:
+		container = kubeType.Spec.Template.Spec.Containers
+	case *DeploymentV1:
 		container = kubeType.Spec.Template.Spec.Containers
 	case *DeploymentExtensionsV1Beta1:
 		container = kubeType.Spec.Template.Spec.Containers
@@ -152,6 +183,8 @@ func getContainers(resource k8sRuntime.Object) (container []Container) {
 	case *ReplicationController:
 		container = kubeType.Spec.Template.Spec.Containers
 	case *StatefulSet:
+		container = kubeType.Spec.Template.Spec.Containers
+	case *StatefulSetV1:
 		container = kubeType.Spec.Template.Spec.Containers
 	}
 	return container

--- a/cmd/k8sruntime_util.go
+++ b/cmd/k8sruntime_util.go
@@ -140,6 +140,12 @@ func setPodAnnotations(resource k8sRuntime.Object, annotations map[string]string
 	case *DaemonSet:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
+	case *DaemonSetV1:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *DeploymentV1:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
 	case *DeploymentV1Beta1:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
@@ -156,6 +162,9 @@ func setPodAnnotations(resource k8sRuntime.Object, annotations map[string]string
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
 	case *StatefulSet:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
+	case *StatefulSetV1:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
 	}
@@ -196,6 +205,10 @@ func getPodAnnotations(resource k8sRuntime.Object) (annotations map[string]strin
 		annotations = kubeType.Spec.JobTemplate.Spec.Template.ObjectMeta.GetAnnotations()
 	case *DaemonSet:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *DaemonSetV1:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *DeploymentV1:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	case *DeploymentV1Beta1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	case *DeploymentV1Beta2:
@@ -207,6 +220,8 @@ func getPodAnnotations(resource k8sRuntime.Object) (annotations map[string]strin
 	case *ReplicationController:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	case *StatefulSet:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *StatefulSetV1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	}
 	return

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -18,7 +18,7 @@ type CronJob = batchv1beta1.CronJob
 // DaemonSet is a type alias for the v1beta1 version of the k8s API.
 type DaemonSet = extensionsv1beta1.DaemonSet
 
-// DaemonSetV1 is a type alias for the v1beta1 version of the k8s API.
+// DaemonSetV1 is a type alias for the v1 version of the k8s API.
 type DaemonSetV1 = appsv1.DaemonSet
 
 // NetworkPolicy is a type alias for the v1 version of the k8s API.
@@ -36,7 +36,7 @@ type SecurityContext = apiv1.SecurityContext
 // StatefulSet is a type alias for the v1beta1 version of the k8s API.
 type StatefulSet = v1beta1.StatefulSet
 
-// StatefulSetV1 is a type alias for the v1beta1 version of the k8s API.
+// StatefulSetV1 is a type alias for the v1 version of the k8s apps API.
 type StatefulSetV1 = appsv1.StatefulSet
 
 // ObjectMeta is a type alias for the v1 version of the k8s API.
@@ -48,13 +48,13 @@ type PodSpec = apiv1.PodSpec
 // DaemonSetList is a type alias for the v1beta1 version of the k8s API.
 type DaemonSetList = extensionsv1beta1.DaemonSetList
 
-// DaemonSetListV1 is a type alias for the v1beta1 version of the k8s API.
+// DaemonSetListV1 is a type alias for the v1 version of the k8s apps API.
 type DaemonSetListV1 = appsv1.DaemonSetList
 
 // DeploymentList is a type alias for the v1beta1 version of the k8s API.
 type DeploymentList = v1beta1.DeploymentList
 
-// DeploymentListV1 is a type alias for the v1 version of the k8s API.
+// DeploymentListV1 is a type alias for the v1 version of the k8s apps API.
 type DeploymentListV1 = appsv1.DeploymentList
 
 // NamespaceList is a type alias for the v1 version of the k8s API.
@@ -72,7 +72,7 @@ type ReplicationControllerList = apiv1.ReplicationControllerList
 // StatefulSetList is a type alias for the v1beta1 version of the k8s API.
 type StatefulSetList = v1beta1.StatefulSetList
 
-// StatefulSetListV1 is a type alias for the v1 version of the k8s API.
+// StatefulSetListV1 is a type alias for the v1 version of the k8s apps API.
 type StatefulSetListV1 = appsv1.StatefulSetList
 
 // Capabilities is a type alias for the v1 version of the k8s API.
@@ -93,7 +93,7 @@ type DeploymentV1Beta1 = v1beta1.Deployment
 // DeploymentV1Beta2 is a type alias for the v1beta2 version of the k8s API.
 type DeploymentV1Beta2 = v1beta2.Deployment
 
-// DeploymentV1 is a type alias for the V1 version of the k8s API.
+// DeploymentV1 is a type alias for the v1 version of the k8s apps API.
 type DeploymentV1 = appsv1.Deployment
 
 // DeploymentExtensionsV1Beta1 is a type alias for the v1beta1 version of the k8s API.

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -17,6 +18,9 @@ type CronJob = batchv1beta1.CronJob
 // DaemonSet is a type alias for the v1beta1 version of the k8s API.
 type DaemonSet = extensionsv1beta1.DaemonSet
 
+// DaemonSetV1 is a type alias for the v1beta1 version of the k8s API.
+type DaemonSetV1 = appsv1.DaemonSet
+
 // NetworkPolicy is a type alias for the v1 version of the k8s API.
 type NetworkPolicy = networking.NetworkPolicy
 
@@ -32,6 +36,9 @@ type SecurityContext = apiv1.SecurityContext
 // StatefulSet is a type alias for the v1beta1 version of the k8s API.
 type StatefulSet = v1beta1.StatefulSet
 
+// StatefulSetV1 is a type alias for the v1beta1 version of the k8s API.
+type StatefulSetV1 = appsv1.StatefulSet
+
 // ObjectMeta is a type alias for the v1 version of the k8s API.
 type ObjectMeta = metav1.ObjectMeta
 
@@ -41,8 +48,14 @@ type PodSpec = apiv1.PodSpec
 // DaemonSetList is a type alias for the v1beta1 version of the k8s API.
 type DaemonSetList = extensionsv1beta1.DaemonSetList
 
+// DaemonSetListV1 is a type alias for the v1beta1 version of the k8s API.
+type DaemonSetListV1 = appsv1.DaemonSetList
+
 // DeploymentList is a type alias for the v1beta1 version of the k8s API.
 type DeploymentList = v1beta1.DeploymentList
+
+// DeploymentListV1 is a type alias for the v1 version of the k8s API.
+type DeploymentListV1 = appsv1.DeploymentList
 
 // NamespaceList is a type alias for the v1 version of the k8s API.
 type NamespaceList = apiv1.NamespaceList
@@ -58,6 +71,9 @@ type ReplicationControllerList = apiv1.ReplicationControllerList
 
 // StatefulSetList is a type alias for the v1beta1 version of the k8s API.
 type StatefulSetList = v1beta1.StatefulSetList
+
+// StatefulSetListV1 is a type alias for the v1 version of the k8s API.
+type StatefulSetListV1 = appsv1.StatefulSetList
 
 // Capabilities is a type alias for the v1 version of the k8s API.
 type Capabilities = apiv1.Capabilities
@@ -77,6 +93,9 @@ type DeploymentV1Beta1 = v1beta1.Deployment
 // DeploymentV1Beta2 is a type alias for the v1beta2 version of the k8s API.
 type DeploymentV1Beta2 = v1beta2.Deployment
 
+// DeploymentV1 is a type alias for the V1 version of the k8s API.
+type DeploymentV1 = appsv1.Deployment
+
 // DeploymentExtensionsV1Beta1 is a type alias for the v1beta1 version of the k8s API.
 type DeploymentExtensionsV1Beta1 = extensionsv1beta1.Deployment
 
@@ -88,7 +107,8 @@ func IsSupportedResourceType(obj runtime.Object) bool {
 	switch obj.(type) {
 	case *CronJob, *DaemonSet, *NetworkPolicy, *Pod, *ReplicationController, *StatefulSet,
 		*DaemonSetList, *DeploymentList, *NamespaceList, *NetworkPolicyList, *PodList, *ReplicationControllerList,
-		*StatefulSetList, *DeploymentV1Beta1, *DeploymentV1Beta2, *DeploymentExtensionsV1Beta1:
+		*StatefulSetList, *DeploymentV1Beta1, *DeploymentV1Beta2, *DeploymentExtensionsV1Beta1,
+		*DeploymentListV1, *DeploymentV1, *DaemonSetV1, *StatefulSetListV1, *DaemonSetListV1, *StatefulSetV1:
 		return true
 	default:
 		return false

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -58,12 +58,22 @@ func newResultFromResource(resource k8sRuntime.Object) (*Result, error) {
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
 		result.Namespace = kubeType.Namespace
+	case *DaemonSetV1:
+		result.KubeType = "daemonSet"
+		result.Labels = kubeType.Spec.Template.Labels
+		result.Name = kubeType.Name
+		result.Namespace = kubeType.Namespace
 	case *DeploymentV1Beta1:
 		result.KubeType = "deployment"
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
 		result.Namespace = kubeType.Namespace
 	case *DeploymentV1Beta2:
+		result.KubeType = "deployment"
+		result.Labels = kubeType.Spec.Template.Labels
+		result.Name = kubeType.Name
+		result.Namespace = kubeType.Namespace
+	case *DeploymentV1:
 		result.KubeType = "deployment"
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
@@ -84,6 +94,11 @@ func newResultFromResource(resource k8sRuntime.Object) (*Result, error) {
 		result.Name = kubeType.Name
 		result.Namespace = kubeType.Namespace
 	case *StatefulSet:
+		result.KubeType = "statefulSet"
+		result.Labels = kubeType.Spec.Template.Labels
+		result.Name = kubeType.Name
+		result.Namespace = kubeType.Namespace
+	case *StatefulSetV1:
 		result.KubeType = "statefulSet"
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
@@ -109,11 +124,19 @@ func newResultFromResourceWithServiceAccountInfo(resource k8sRuntime.Object) (*R
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
+	case *DaemonSetV1:
+		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
+		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
+		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
 	case *DeploymentV1Beta1:
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
 	case *DeploymentV1Beta2:
+		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
+		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
+		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
+	case *DeploymentV1:
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
@@ -130,6 +153,10 @@ func newResultFromResourceWithServiceAccountInfo(resource k8sRuntime.Object) (*R
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
 	case *StatefulSet:
+		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
+		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
+		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
+	case *StatefulSetV1:
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken

--- a/fixtures/allow_privilege_escalation_misconfigured_allow.yml
+++ b/fixtures/allow_privilege_escalation_misconfigured_allow.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: fakeStatefulSetAPE

--- a/fixtures/allow_privilege_escalation_misconfigured_allow_v1beta1.yml
+++ b/fixtures/allow_privilege_escalation_misconfigured_allow_v1beta1.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: fakeStatefulSetAPE
+  namespace: fakeStatefulSetAPE
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeAllowPrivilegeEscalation
+        audit.kubernetes.io/allow-privilege-escalation: "Superuser privileges needed"
+    spec:
+      containers:
+      - name: fakeContainerAPE
+        securityContext:
+            allowPrivilegeEscalation: false

--- a/fixtures/allow_privilege_escalation_nil.yml
+++ b/fixtures/allow_privilege_escalation_nil.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null

--- a/fixtures/allow_privilege_escalation_nil_v1beta1.yml
+++ b/fixtures/allow_privilege_escalation_nil_v1beta1.yml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  name: fakeStatefulSetAPE
+  namespace: fakeStatefulSetAPE
+spec:
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAllowPrivilegeEscalation
+    spec:
+      containers:
+      - name: fakeContainerAPE
+        resources: {}
+        securityContext: {}
+  updateStrategy: {}
+status:
+  replicas: 0

--- a/fixtures/allow_privilege_escalation_true.yml
+++ b/fixtures/allow_privilege_escalation_true.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null

--- a/fixtures/allow_privilege_escalation_true_allowed.yml
+++ b/fixtures/allow_privilege_escalation_true_allowed.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: fakeStatefulSetAPE

--- a/fixtures/allow_privilege_escalation_true_allowed_v1beta1.yml
+++ b/fixtures/allow_privilege_escalation_true_allowed_v1beta1.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: fakeStatefulSetAPE
+  namespace: fakeStatefulSetAPE
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeAllowPrivilegeEscalation
+        audit.kubernetes.io/allow-privilege-escalation: "Superuser privileges needed"
+    spec:
+      containers:
+      - name: fakeContainerAPE
+        securityContext:
+            allowPrivilegeEscalation: true

--- a/fixtures/allow_privilege_escalation_true_v1beta1.yml
+++ b/fixtures/allow_privilege_escalation_true_v1beta1.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  name: fakeStatefulSetAPE
+  namespace: fakeStatefulSetAPE
+spec:
+  serviceName: ""
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAllowPrivilegeEscalation
+    spec:
+      containers:
+      - name: fakeContainerAPE
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: true
+  updateStrategy: {}
+status:
+  replicas: 0

--- a/fixtures/audit_all.yml
+++ b/fixtures/audit_all.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/fixtures/audit_all_v1beta1.yml
+++ b/fixtures/audit_all_v1beta1.yml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: allAudits
+  namespace: fakeDeploymentSC
+spec:
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeSecurityContext
+    spec:
+      containers:
+      - name: fakeContainerSC
+        resources: {}
+status: {}

--- a/fixtures/autofix-fixed.yml
+++ b/fixtures/autofix-fixed.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/fixtures/autofix-fixed_v1beta1.yml
+++ b/fixtures/autofix-fixed_v1beta1.yml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: cababilitiesAdded
+  namespace: fakeDeploymentSC
+spec:
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeSecurityContext
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        container.apparmor.security.beta.kubernetes.io/fakeContainerSC1: runtime/default
+        container.apparmor.security.beta.kubernetes.io/fakeContainerSC2: runtime/default
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: fakeContainerSC1
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - AUDIT_WRITE
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - FSETID
+            - KILL
+            - MKNOD
+            - NET_BIND_SERVICE
+            - NET_RAW
+            - SETFCAP
+            - SETGID
+            - SETPCAP
+            - SETUID
+            - SYS_CHROOT
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+      - name: fakeContainerSC2
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - AUDIT_WRITE
+            - CHOWN
+            - DAC_OVERRIDE
+            - FOWNER
+            - FSETID
+            - KILL
+            - MKNOD
+            - NET_BIND_SERVICE
+            - NET_RAW
+            - SETFCAP
+            - SETGID
+            - SETPCAP
+            - SETUID
+            - SYS_CHROOT
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+status: {}

--- a/fixtures/autofix.yml
+++ b/fixtures/autofix.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/fixtures/autofix_v1beta1.yml
+++ b/fixtures/autofix_v1beta1.yml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: cababilitiesAdded
+  namespace: fakeDeploymentSC
+spec:
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeSecurityContext
+    spec:
+      containers:
+      - name: fakeContainerSC1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - AUDIT_WRITE
+      - name: fakeContainerSC2

--- a/fixtures/double-name.yml
+++ b/fixtures/double-name.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/fixtures/image_tag_missing.yml
+++ b/fixtures/image_tag_missing.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/fixtures/image_tag_present.yml
+++ b/fixtures/image_tag_present.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/fixtures/privileged_misconfigured_allow.yml
+++ b/fixtures/privileged_misconfigured_allow.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fakeDaemonSetPrivileged2

--- a/fixtures/privileged_nil.yml
+++ b/fixtures/privileged_nil.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   creationTimestamp: null

--- a/fixtures/privileged_true.yml
+++ b/fixtures/privileged_true.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   creationTimestamp: null

--- a/fixtures/privileged_true_allowed.yml
+++ b/fixtures/privileged_true_allowed.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fakeDaemonSetPrivileged2

--- a/fixtures/read_only_root_filesystem_false.yml
+++ b/fixtures/read_only_root_filesystem_false.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null

--- a/fixtures/read_only_root_filesystem_false_allowed.yml
+++ b/fixtures/read_only_root_filesystem_false_allowed.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: fakeStatefulSetRORF3

--- a/fixtures/read_only_root_filesystem_misconfigured_allow.yml
+++ b/fixtures/read_only_root_filesystem_misconfigured_allow.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: fakeStatefulSetRORF3

--- a/fixtures/read_only_root_filesystem_nil.yml
+++ b/fixtures/read_only_root_filesystem_nil.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null

--- a/fixtures/run_as_non_root_false.yml
+++ b/fixtures/run_as_non_root_false.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -6,6 +6,9 @@ metadata:
   namespace: fakeDeploymentRANR
 spec:
   strategy: {}
+  selector:
+    matchLabels:
+      apps: fakeRunAsNonRoot
   template:
     metadata:
       creationTimestamp: null

--- a/fixtures/run_as_non_root_false_allowed.yml
+++ b/fixtures/run_as_non_root_false_allowed.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: allow_run_as_root

--- a/fixtures/run_as_non_root_misconfigured_allow.yml
+++ b/fixtures/run_as_non_root_misconfigured_allow.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: allow_run_as_root

--- a/fixtures/run_as_non_root_nil.yml
+++ b/fixtures/run_as_non_root_nil.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/fixtures/security_context_nil.yml
+++ b/fixtures/security_context_nil.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/fixtures/security_context_nil_v1beta1.yml
+++ b/fixtures/security_context_nil_v1beta1.yml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: security_context_nil
+  namespace: fakeDeploymentRANR
+spec:
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeRunAsNonRoot
+    spec:
+      containers:
+      - name: fakeContainerRANR
+        resources: {}
+status: {}


### PR DESCRIPTION
Signed-off-by: Johannes M. Scheuermann <joh.scheuer@gmail.com>

Since Kubernetes 1.9+ all workloads are under `apps/v1` see: https://v1-9.docs.kubernetes.io/docs/reference/workloads-18-19 kubeaudit should support the API version  `apps/v1`. This is actually currently mostly an issue if you use kubeaudit with the `-f/--manifest` flag because the Kubernetes API still returns `extensions/v1beta1` for these types.

This PR adds support for all workload under the API Group `apps/v1`:

```bash
$ kubectl api-resources --api-group=apps
NAME                  SHORTNAMES   APIGROUP   NAMESPACED   KIND
controllerrevisions                apps       true         ControllerRevision #Not implemented
daemonsets            ds           apps       true         DaemonSet
deployments           deploy       apps       true         Deployment
replicasets           rs           apps       true         ReplicaSet
statefulsets          sts          apps       true         StatefulSet
```

Fixes: https://github.com/Shopify/kubeaudit/issues/126