### PR TITLE
Fix version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,8 +20,9 @@ builds:
   - 6
   - 7
   main: .
-  ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
   binary: kubeaudit
+  ldflags:
+  - -s -w -X github.com/Shopify/kubeaudit/cmd.Version={{.Version}} -X github.com/Shopify/kubeaudit/cmd.Commit={{.Commit}} -X github.com/Shopify/kubeaudit/cmd.BuildDate={{.Date}}
 archive:
   format: tar.gz
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{.Arm }}{{ end }}'

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -506,7 +506,6 @@
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
-    "k8s.io/client-go/pkg/version",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/plugin/pkg/client/auth/oidc",
     "k8s.io/client-go/rest",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:4216202f4088a73e2982df875e2f0d1401137bbc248e57391e70547af167a18a"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = ""
+  revision = "72bf35d0ff611848c1dc9df0f976c81192392fa5"
+  version = "v4.1.0"
+
+[[projects]]
   digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
   name = "github.com/ghodss/yaml"
   packages = ["."]
@@ -402,15 +410,18 @@
     "pkg/util/framer",
     "pkg/util/intstr",
     "pkg/util/json",
+    "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/runtime",
     "pkg/util/sets",
+    "pkg/util/strategicpatch",
     "pkg/util/validation",
     "pkg/util/validation/field",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
+    "third_party/forked/golang/json",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
@@ -422,40 +433,74 @@
   name = "k8s.io/client-go"
   packages = [
     "discovery",
+    "discovery/fake",
     "kubernetes",
+    "kubernetes/fake",
     "kubernetes/scheme",
     "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1alpha1/fake",
     "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/admissionregistration/v1beta1/fake",
     "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1/fake",
     "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta1/fake",
     "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/apps/v1beta2/fake",
     "kubernetes/typed/auditregistration/v1alpha1",
+    "kubernetes/typed/auditregistration/v1alpha1/fake",
     "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1/fake",
     "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authentication/v1beta1/fake",
     "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1/fake",
     "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/authorization/v1beta1/fake",
     "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v1/fake",
     "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta1/fake",
     "kubernetes/typed/autoscaling/v2beta2",
+    "kubernetes/typed/autoscaling/v2beta2/fake",
     "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1/fake",
     "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v1beta1/fake",
     "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/batch/v2alpha1/fake",
     "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/certificates/v1beta1/fake",
     "kubernetes/typed/coordination/v1beta1",
+    "kubernetes/typed/coordination/v1beta1/fake",
     "kubernetes/typed/core/v1",
+    "kubernetes/typed/core/v1/fake",
     "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/events/v1beta1/fake",
     "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/extensions/v1beta1/fake",
     "kubernetes/typed/networking/v1",
+    "kubernetes/typed/networking/v1/fake",
     "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/policy/v1beta1/fake",
     "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1/fake",
     "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1alpha1/fake",
     "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/rbac/v1beta1/fake",
     "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1alpha1/fake",
     "kubernetes/typed/scheduling/v1beta1",
+    "kubernetes/typed/scheduling/v1beta1/fake",
     "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/settings/v1alpha1/fake",
     "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1/fake",
     "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1alpha1/fake",
     "kubernetes/typed/storage/v1beta1",
+    "kubernetes/typed/storage/v1beta1/fake",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
     "pkg/apis/clientauthentication/v1beta1",
@@ -465,6 +510,7 @@
     "plugin/pkg/client/auth/oidc",
     "rest",
     "rest/watch",
+    "testing",
     "third_party/forked/golang/template",
     "tools/auth",
     "tools/clientcmd",
@@ -483,6 +529,14 @@
   ]
   pruneopts = ""
   revision = "6054fbfc6590b87164caebe1aae4b14024c03066"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3b098aa71211bf4f6930aacc51f5a356a1f267072cf52e26243685d9eba3d183"
+  name = "k8s.io/kube-openapi"
+  packages = ["pkg/util/proto"]
+  pruneopts = ""
+  revision = "72693cb1fadd73ae2742f6fe29af77d1aecdd8cd"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -504,7 +558,10 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/version",
+    "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/plugin/pkg/client/auth/oidc",

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 BINARY_NAME=kubeaudit
 BINARY_UNIX=$(BINARY_NAME)_unix
+LDFLAGS=$(shell build/ldflags.sh)
 
 # kubernetes client won't build with go<1.10
 GOVERSION:=$(shell go version | awk '{print $$3}')
@@ -18,7 +19,7 @@ endif
 all: setup test build
 
 build:
-	$(GOBUILD) -o $(BINARY_NAME) -v
+	$(GOBUILD) -o $(BINARY_NAME) -v -ldflags=all="$(LDFLAGS)"
 
 install:
 	cp $(BINARY_NAME) $(GOPATH)/bin/kubeaudit

--- a/build/ldflags.sh
+++ b/build/ldflags.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+VERSION=${VERSION:-$(git describe --abbrev=0 --broken)}
+COMMIT=${COMMIT:-$(git rev-parse --short HEAD)}
+# BSD date command doesn't support RFC3339/ISO8601 or subsecond precision.
+BUILDDATE=${BUILDDATE:-$(date -u -Ins 2> /dev/null || true)}
+BUILDDATE=${BUILDDATE:-$(date -u +%FT%T000000000%z)}
+
+new_ldflags="-X \"github.com/Shopify/kubeaudit/cmd.Version=${VERSION}\""
+new_ldflags+=" -X \"github.com/Shopify/kubeaudit/cmd.Commit=${COMMIT}\""
+new_ldflags+=" -X \"github.com/Shopify/kubeaudit/cmd.BuildDate=${BUILDDATE}\""
+
+export LDFLAGS="$new_ldflags ${LDFLAGS:-}"
+echo "$LDFLAGS"

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // auth for GKE clusters
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // auth for OIDC
 	"k8s.io/client-go/rest"
@@ -138,11 +137,4 @@ func printKubernetesVersion(clientset *kubernetes.Clientset) {
 		"Minor":    serverInfo.Minor,
 		"Platform": serverInfo.Platform,
 	}).Info("Kubernetes server version")
-
-	clientInfo := version.Get()
-	log.WithFields(log.Fields{
-		"Major":    clientInfo.Major,
-		"Minor":    clientInfo.Minor,
-		"Platform": clientInfo.Platform,
-	}).Info("Kubernetes client version")
 }

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // auth for GKE clusters
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // auth for OIDC
@@ -126,15 +127,7 @@ func getNetworkPolicies(clientset *kubernetes.Clientset) *networking.NetworkPoli
 	return netPols
 }
 
-func printKubernetesVersion(clientset *kubernetes.Clientset) {
+func getKubernetesVersion(clientset kubernetes.Interface) (*version.Info, error) {
 	discoveryClient := clientset.Discovery()
-	serverInfo, err := discoveryClient.ServerVersion()
-	if err != nil {
-		log.Error(err)
-	}
-	log.WithFields(log.Fields{
-		"Major":    serverInfo.Major,
-		"Minor":    serverInfo.Minor,
-		"Platform": serverInfo.Platform,
-	}).Info("Kubernetes server version")
+	return discoveryClient.ServerVersion()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ func init() {
 	cobra.OnInitialize(processFlags)
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.localMode, "local", "l", false, "[DEPRECATED] Local mode, uses $HOME/.kube/config as configuration")
 	RootCmd.Flags().MarkHidden("local")
-	RootCmd.PersistentFlags().StringVarP(&rootConfig.kubeConfig, "kubeconfig", "c", "", "Specify local config file (default is $HOME/.kube/config")
+	RootCmd.PersistentFlags().StringVarP(&rootConfig.kubeConfig, "kubeconfig", "c", "", "Specify local config file (default is $HOME/.kube/config)")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.verbose, "verbose", "v", "INFO", "Set the debug level")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.json, "json", "j", false, "Enable json logging")
 	RootCmd.PersistentFlags().BoolVarP(&rootConfig.allPods, "allPods", "a", false, "Audit againsts pods in all the phases (default Running Phase)")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,25 +8,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Placeholder values will be overridden by goreleaser or makefile.
+var (
+	Version   = "0.0.0"
+	Commit    = "ffffffff"
+	BuildDate = "2006-01-02T15:04:05Z07:00"
+)
+
 func init() {
 	RootCmd.AddCommand(versionCmd)
 }
-
-// Version is the semantic versioning number for kubeaudit.
-const Version = "0.1.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of kubeaudit",
 	Long:  `This just prints the version of kubeaudit`,
 	Run: func(cmd *cobra.Command, args []string) {
-		ver, err := version.NewVersion(Version)
+		_, err := version.NewVersion(Version + "+" + Commit)
 		if err != nil {
 			log.Error(err)
 			os.Exit(1)
 		}
 		log.WithFields(log.Fields{
-			"Version": ver,
+			"BuildDate": BuildDate,
+			"Commit":    Commit,
+			"Version":   Version,
 		}).Info("Kubeaudit")
 
 		kube, err := kubeClient()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,7 +22,7 @@ func init() {
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of kubeaudit",
-	Long:  `This just prints the version of kubeaudit`,
+	Long:  `This prints the version numbers of kubeaudit and the kubernetes server.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		_, err := version.NewVersion(Version + "+" + Commit)
 		if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -33,13 +33,26 @@ var versionCmd = &cobra.Command{
 			"BuildDate": BuildDate,
 			"Commit":    Commit,
 			"Version":   Version,
-		}).Info("Kubeaudit")
+		}).Info("Kubeaudit version")
 
-		kube, err := kubeClient()
-		if err != nil {
-			log.Warn("Could not get kubernetes server version.")
-			return
-		}
-		printKubernetesVersion(kube)
+		printServerVersion()
 	},
+}
+
+func printServerVersion() {
+	kube, err := kubeClient()
+	if err != nil {
+		return
+	}
+
+	v, err := getKubernetesVersion(kube)
+	if err != nil {
+		return
+	}
+
+	log.WithFields(log.Fields{
+		"Major":    v.Major,
+		"Minor":    v.Minor,
+		"Platform": v.Platform,
+	}).Info("Kubernetes server version")
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionCmd(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.SetOutput(buf)
+
+	cmd := RootCmd
+	cmd.SetArgs([]string{"version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal("Version command returned an error.")
+	}
+
+	type exp struct {
+		str string
+		msg string
+	}
+
+	exps := []exp{
+		{`.*level=info\s+msg="Kubeaudit version"\s+BuildDate=\S+\s+Commit=[[:xdigit:]]+\s+Version=\d+\.\d+\.\d+.*`,
+			"invalid kubeaudit version"},
+	}
+
+	for _, e := range exps {
+		assert.Regexp(t, regexp.MustCompile(e.str), buf, e.msg)
+	}
+}


### PR DESCRIPTION
A few releases in a row showed incorrect version numbers. This change will prevent that by automatically versioning builds based on the commit SHA and tag. For example:
```
./kubeaudit version
INFO[0000] Kubeaudit version BuildDate="2018-11-05T20:50:42000000000+0000" Commit=e5abb2c Version=v0.3.0
```

The version command will only output server version information if there is a kubernetes server to connect to (based on command switches and environment settings). This PR adds testing for the version command, to prevent issues like #112.

It also closes #115 by removing the attempt to display non-existent client version information. 