### PR TITLE
Use printf instead of echo to avoid shell incompatibility with -e.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGS=$(shell build/ldflags.sh)
 # kubernetes client won't build with go<1.10
 GOVERSION:=$(shell go version | awk '{print $$3}')
 GOVERSION_MIN:=go1.10
-GOVERSION_CHECK=$(shell echo "$(GOVERSION)\n$(GOVERSION_MIN)" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -n 1)
+GOVERSION_CHECK=$(shell printf "%s\n%s\n" "$(GOVERSION)" "$(GOVERSION_MIN)" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -n 1)
 
 ifneq ($(GOVERSION_MIN), $(GOVERSION_CHECK))
 $(error Detected Go version $(GOVERSION) < required version $(GOVERSION_MIN))


### PR DESCRIPTION
Echo behaves differently in different shells. Some require -e to expand \n, but others don't have a -e switch. This change makes the version check compatible with most shells.