### PR TITLE
Rename kubernetes type aliases to include versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -548,6 +548,7 @@
     "github.com/spf13/cobra",
     "github.com/stretchr/testify/assert",
     "gopkg.in/yaml.v2",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/apps/v1beta2",
     "k8s.io/api/batch/v1beta1",

--- a/cmd/allowPrivilegeEscalation.go
+++ b/cmd/allowPrivilegeEscalation.go
@@ -6,7 +6,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
-func checkAllowPrivilegeEscalation(container Container, result *Result) {
+func checkAllowPrivilegeEscalation(container ContainerV1, result *Result) {
 	if reason := result.Labels["audit.kubernetes.io/allow-privilege-escalation"]; reason == "" {
 		if container.SecurityContext == nil || container.SecurityContext.AllowPrivilegeEscalation == nil {
 			occ := Occurrence{

--- a/cmd/allowPrivilegeEscalation_fixes.go
+++ b/cmd/allowPrivilegeEscalation_fixes.go
@@ -3,7 +3,7 @@ package cmd
 import k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 
 func fixAllowPrivilegeEscalation(resource k8sRuntime.Object, occurrence Occurrence) k8sRuntime.Object {
-	var containers []Container
+	var containers []ContainerV1
 	for _, container := range getContainers(resource) {
 		if occurrence.container == container.Name {
 			container.SecurityContext.AllowPrivilegeEscalation = newFalse()

--- a/cmd/automountServiceAccountToken_fixes_test.go
+++ b/cmd/automountServiceAccountToken_fixes_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestFixServiceAccountTokenDeprecated(t *testing.T) {
 	assert, resource := FixTestSetup(t, "service_account_token_deprecated.yml", auditAutomountServiceAccountToken)
 	switch typ := resource.(type) {
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		assert.Equal("", typ.Spec.Template.Spec.DeprecatedServiceAccount)
 	}
 }
@@ -13,7 +13,7 @@ func TestFixServiceAccountTokenDeprecated(t *testing.T) {
 func TestFixServiceAccountTokenTrueAndNoName(t *testing.T) {
 	assert, resource := FixTestSetup(t, "service_account_token_true_and_no_name.yml", auditAutomountServiceAccountToken)
 	switch typ := resource.(type) {
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		assert.False(*typ.Spec.Template.Spec.AutomountServiceAccountToken)
 	}
 }
@@ -21,7 +21,7 @@ func TestFixServiceAccountTokenTrueAndNoName(t *testing.T) {
 func TestFixServiceAccountTokenNilAndNoName(t *testing.T) {
 	assert, resource := FixTestSetup(t, "service_account_token_nil_and_no_name.yml", auditAutomountServiceAccountToken)
 	switch typ := resource.(type) {
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		assert.False(*typ.Spec.Template.Spec.AutomountServiceAccountToken)
 	}
 }
@@ -29,7 +29,7 @@ func TestFixServiceAccountTokenNilAndNoName(t *testing.T) {
 func TestFixServiceAccountTokenTrueAllowed(t *testing.T) {
 	assert, resource := FixTestSetup(t, "service_account_token_true_allowed.yml", auditAutomountServiceAccountToken)
 	switch typ := resource.(type) {
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		assert.True(*typ.Spec.Template.Spec.AutomountServiceAccountToken)
 	}
 }
@@ -37,7 +37,7 @@ func TestFixServiceAccountTokenTrueAllowed(t *testing.T) {
 func TestFixServiceAccountTokenMisconfiguredAllow(t *testing.T) {
 	assert, resource := FixTestSetup(t, "service_account_token_misconfigured_allow.yml", auditAutomountServiceAccountToken)
 	switch typ := resource.(type) {
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		assert.False(*typ.Spec.Template.Spec.AutomountServiceAccountToken)
 	}
 }

--- a/cmd/cap_set.go
+++ b/cmd/cap_set.go
@@ -3,10 +3,10 @@ package cmd
 import "sort"
 
 // CapSet represents a set of capabilities.
-type CapSet map[Capability]bool
+type CapSet map[CapabilityV1]bool
 
 // NewCapSetFromArray converts an array of capabilities into a CapSet.
-func NewCapSetFromArray(array []Capability) (set CapSet) {
+func NewCapSetFromArray(array []CapabilityV1) (set CapSet) {
 	set = make(CapSet)
 	for _, cap := range array {
 		set[cap] = true
@@ -24,7 +24,7 @@ func mergeCapSets(sets ...CapSet) (merged CapSet) {
 	return
 }
 
-func sortCapSet(capSet CapSet) (sorted []Capability) {
+func sortCapSet(capSet CapSet) (sorted []CapabilityV1) {
 	keys := []string{}
 	for key := range capSet {
 		keys = append(keys, string(key))
@@ -32,7 +32,7 @@ func sortCapSet(capSet CapSet) (sorted []Capability) {
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		sorted = append(sorted, Capability(key))
+		sorted = append(sorted, CapabilityV1(key))
 	}
 	return
 }

--- a/cmd/cap_set_test.go
+++ b/cmd/cap_set_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestNewCapSetFromArray(t *testing.T) {
 	assert := assert.New(t)
-	capArray := []Capability{"AUDIT_WRITE", "CHOWN"}
+	capArray := []CapabilityV1{"AUDIT_WRITE", "CHOWN"}
 	capSet := CapSet{"AUDIT_WRITE": true, "CHOWN": true}
 	assert.Equal(NewCapSetFromArray(capArray), capSet)
 }
@@ -24,5 +24,5 @@ func TestMergeCapSets(t *testing.T) {
 func TestSortCapSet(t *testing.T) {
 	assert := assert.New(t)
 	sorted := sortCapSet(CapSet{"DAC_OVVERRIDE": true, "AUDIT_WRITE": true, "CHOWN": true})
-	assert.Equal([]Capability{"AUDIT_WRITE", "CHOWN", "DAC_OVVERRIDE"}, sorted)
+	assert.Equal([]CapabilityV1{"AUDIT_WRITE", "CHOWN", "DAC_OVVERRIDE"}, sorted)
 }

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -54,12 +54,12 @@ func recommendedCapabilitiesToBeDropped() (dropCapSet CapSet, err error) {
 	}
 	dropCapSet = make(CapSet)
 	for _, drop := range caps.Drop {
-		dropCapSet[Capability(drop)] = true
+		dropCapSet[CapabilityV1(drop)] = true
 	}
 	return
 }
 
-func checkCapabilities(container Container, result *Result) {
+func checkCapabilities(container ContainerV1, result *Result) {
 	added := CapSet{}
 	dropped := CapSet{}
 	allCapsDrop := false

--- a/cmd/capabilities_fixes.go
+++ b/cmd/capabilities_fixes.go
@@ -3,16 +3,16 @@ package cmd
 import k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 
 func fixCapabilitiesNil(resource k8sRuntime.Object) k8sRuntime.Object {
-	var containers []Container
+	var containers []ContainerV1
 	for _, container := range getContainers(resource) {
 		if container.SecurityContext.Capabilities == nil {
-			container.SecurityContext.Capabilities = &Capabilities{}
+			container.SecurityContext.Capabilities = &CapabilitiesV1{}
 		}
 		if container.SecurityContext.Capabilities.Drop == nil {
-			container.SecurityContext.Capabilities.Drop = []Capability{}
+			container.SecurityContext.Capabilities.Drop = []CapabilityV1{}
 		}
 		if container.SecurityContext.Capabilities.Add == nil {
-			container.SecurityContext.Capabilities.Add = []Capability{}
+			container.SecurityContext.Capabilities.Add = []CapabilityV1{}
 		}
 		containers = append(containers, container)
 	}
@@ -20,10 +20,10 @@ func fixCapabilitiesNil(resource k8sRuntime.Object) k8sRuntime.Object {
 }
 
 func fixCapabilityNotDropped(resource k8sRuntime.Object, occurrence Occurrence) k8sRuntime.Object {
-	var containers []Container
+	var containers []ContainerV1
 	for _, container := range getContainers(resource) {
 		if occurrence.container == container.Name {
-			container.SecurityContext.Capabilities.Drop = append(container.SecurityContext.Capabilities.Drop, Capability(occurrence.metadata["CapName"]))
+			container.SecurityContext.Capabilities.Drop = append(container.SecurityContext.Capabilities.Drop, CapabilityV1(occurrence.metadata["CapName"]))
 		}
 		containers = append(containers, container)
 	}
@@ -31,10 +31,10 @@ func fixCapabilityNotDropped(resource k8sRuntime.Object, occurrence Occurrence) 
 }
 
 func fixCapabilityAdded(resource k8sRuntime.Object, occurrence Occurrence) k8sRuntime.Object {
-	var containers []Container
+	var containers []ContainerV1
 	for _, container := range getContainers(resource) {
 		if occurrence.container == container.Name {
-			add := []Capability{}
+			add := []CapabilityV1{}
 			for _, cap := range container.SecurityContext.Capabilities.Add {
 				if string(cap) != occurrence.metadata["CapName"] {
 					add = append(add, cap)

--- a/cmd/capabilities_fixes_test.go
+++ b/cmd/capabilities_fixes_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func assertAllDropped(assert *assert.Assertions, dropped []Capability, allowed ...[]Capability) {
-	toBeDropped := []Capability{"AUDIT_WRITE", "CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETUID", "SETPCAP", "SYS_CHROOT"}
+func assertAllDropped(assert *assert.Assertions, dropped []CapabilityV1, allowed ...[]CapabilityV1) {
+	toBeDropped := []CapabilityV1{"AUDIT_WRITE", "CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETUID", "SETPCAP", "SYS_CHROOT"}
 	for _, cap := range toBeDropped {
 		skip := false
 		if allowed != nil {
@@ -28,7 +28,7 @@ func assertAllDropped(assert *assert.Assertions, dropped []Capability, allowed .
 
 func TestFixCapabilitiesNotDropped(t *testing.T) {
 	assert, resource := FixTestSetup(t, "capabilities_nil.yml", auditCapabilities)
-	add := []Capability{}
+	add := []CapabilityV1{}
 	for _, container := range getContainers(resource) {
 		assert.Equal(add, container.SecurityContext.Capabilities.Add)
 		assertAllDropped(assert, container.SecurityContext.Capabilities.Drop)
@@ -37,16 +37,16 @@ func TestFixCapabilitiesNotDropped(t *testing.T) {
 
 func TestFixCapabilitySomeAllowed(t *testing.T) {
 	assert, resource := FixTestSetup(t, "capabilities_some_allowed.yml", auditCapabilities)
-	add := []Capability{"SYS_TIME"}
+	add := []CapabilityV1{"SYS_TIME"}
 	for _, container := range getContainers(resource) {
 		assert.Equal(add, container.SecurityContext.Capabilities.Add)
-		assertAllDropped(assert, container.SecurityContext.Capabilities.Drop, []Capability{"CHOWN"})
+		assertAllDropped(assert, container.SecurityContext.Capabilities.Drop, []CapabilityV1{"CHOWN"})
 	}
 }
 
 func TestFixCapabilitiesNil(t *testing.T) {
 	assert, resource := FixTestSetup(t, "capabilities_nil.yml", auditCapabilities)
-	add := []Capability{}
+	add := []CapabilityV1{}
 	for _, container := range getContainers(resource) {
 		assert.Equal(add, container.SecurityContext.Capabilities.Add)
 		assertAllDropped(assert, container.SecurityContext.Capabilities.Drop)
@@ -55,7 +55,7 @@ func TestFixCapabilitiesNil(t *testing.T) {
 
 func TestFixCapabilitiesAdded(t *testing.T) {
 	assert, resource := FixTestSetup(t, "capabilities_added.yml", auditCapabilities)
-	add := []Capability{}
+	add := []CapabilityV1{}
 	for _, container := range getContainers(resource) {
 		assert.Equal(add, container.SecurityContext.Capabilities.Add)
 		assertAllDropped(assert, container.SecurityContext.Capabilities.Drop)
@@ -64,7 +64,7 @@ func TestFixCapabilitiesAdded(t *testing.T) {
 
 func TestFixCapabilitiesSomeDropped(t *testing.T) {
 	assert, resource := FixTestSetup(t, "capabilities_some_dropped.yml", auditCapabilities)
-	add := []Capability{}
+	add := []CapabilityV1{}
 	for _, container := range getContainers(resource) {
 		assert.Equal(add, container.SecurityContext.Capabilities.Add)
 		assertAllDropped(assert, container.SecurityContext.Capabilities.Drop)
@@ -73,7 +73,7 @@ func TestFixCapabilitiesSomeDropped(t *testing.T) {
 
 func TestFixCapabilitiesMisconfiguredAllow(t *testing.T) {
 	assert, resource := FixTestSetup(t, "capabilities_misconfigured_allow.yml", auditCapabilities)
-	add := []Capability{}
+	add := []CapabilityV1{}
 	for _, container := range getContainers(resource) {
 		if container.SecurityContext.Capabilities.Add == nil {
 			fmt.Println("it is nil!")

--- a/cmd/capabilities_test.go
+++ b/cmd/capabilities_test.go
@@ -10,7 +10,7 @@ func TestRecommendedCapabilitiesToBeDropped(t *testing.T) {
 	assert := assert.New(t)
 	capabilities, err := recommendedCapabilitiesToBeDropped()
 	assert.Nil(err)
-	assert.Equal(NewCapSetFromArray([]Capability{"AUDIT_WRITE", "CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETUID", "SETPCAP", "SYS_CHROOT"}), capabilities, "")
+	assert.Equal(NewCapSetFromArray([]CapabilityV1{"AUDIT_WRITE", "CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETUID", "SETPCAP", "SYS_CHROOT"}), capabilities, "")
 }
 
 func TestSecurityContextNil_SC(t *testing.T) {

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -26,7 +26,7 @@ func (image *imgFlags) splitImageString() {
 	}
 }
 
-func checkImage(container Container, image imgFlags, result *Result) {
+func checkImage(container ContainerV1, image imgFlags, result *Result) {
 	image.splitImageString()
 	contImage := imgFlags{img: container.Image}
 	contImage.splitImageString()

--- a/cmd/k8sruntime_util.go
+++ b/cmd/k8sruntime_util.go
@@ -9,12 +9,12 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func setContainers(resource k8sRuntime.Object, containers []Container) k8sRuntime.Object {
+func setContainers(resource k8sRuntime.Object, containers []ContainerV1) k8sRuntime.Object {
 	switch t := resource.(type) {
-	case *CronJob:
+	case *CronJobV1Beta1:
 		t.Spec.JobTemplate.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
-	case *DaemonSet:
+	case *DaemonSetV1Beta1:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
 	case *DaemonSetV1:
@@ -32,13 +32,13 @@ func setContainers(resource k8sRuntime.Object, containers []Container) k8sRuntim
 	case *DeploymentExtensionsV1Beta1:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
-	case *Pod:
+	case *PodV1:
 		t.Spec.Containers = containers
 		return t.DeepCopyObject()
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
-	case *StatefulSet:
+	case *StatefulSetV1Beta1:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
 	case *StatefulSetV1:
@@ -50,10 +50,10 @@ func setContainers(resource k8sRuntime.Object, containers []Container) k8sRuntim
 
 func disableDSA(resource k8sRuntime.Object) k8sRuntime.Object {
 	switch t := resource.(type) {
-	case *CronJob:
+	case *CronJobV1Beta1:
 		t.Spec.JobTemplate.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
-	case *DaemonSet:
+	case *DaemonSetV1Beta1:
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DaemonSetV1:
@@ -71,13 +71,13 @@ func disableDSA(resource k8sRuntime.Object) k8sRuntime.Object {
 	case *DeploymentExtensionsV1Beta1:
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
-	case *Pod:
+	case *PodV1:
 		t.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
-	case *StatefulSet:
+	case *StatefulSetV1Beta1:
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *StatefulSetV1:
@@ -95,10 +95,10 @@ func setASAT(resource k8sRuntime.Object, b bool) k8sRuntime.Object {
 		boolean = newFalse()
 	}
 	switch t := resource.(type) {
-	case *CronJob:
+	case *CronJobV1Beta1:
 		t.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
-	case *DaemonSet:
+	case *DaemonSetV1Beta1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
 	case *DaemonSetV1:
@@ -116,13 +116,13 @@ func setASAT(resource k8sRuntime.Object, b bool) k8sRuntime.Object {
 	case *DeploymentExtensionsV1Beta1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
-	case *Pod:
+	case *PodV1:
 		t.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
-	case *StatefulSet:
+	case *StatefulSetV1Beta1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
 	case *StatefulSetV1:
@@ -134,10 +134,10 @@ func setASAT(resource k8sRuntime.Object, b bool) k8sRuntime.Object {
 
 func setPodAnnotations(resource k8sRuntime.Object, annotations map[string]string) k8sRuntime.Object {
 	switch kubeType := resource.(type) {
-	case *CronJob:
+	case *CronJobV1Beta1:
 		kubeType.Spec.JobTemplate.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
-	case *DaemonSet:
+	case *DaemonSetV1Beta1:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
 	case *DaemonSetV1:
@@ -155,13 +155,13 @@ func setPodAnnotations(resource k8sRuntime.Object, annotations map[string]string
 	case *DeploymentExtensionsV1Beta1:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
-	case *Pod:
+	case *PodV1:
 		kubeType.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
-	case *StatefulSet:
+	case *StatefulSetV1Beta1:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
 	case *StatefulSetV1:
@@ -171,11 +171,11 @@ func setPodAnnotations(resource k8sRuntime.Object, annotations map[string]string
 	return resource
 }
 
-func getContainers(resource k8sRuntime.Object) (container []Container) {
+func getContainers(resource k8sRuntime.Object) (container []ContainerV1) {
 	switch kubeType := resource.(type) {
-	case *CronJob:
+	case *CronJobV1Beta1:
 		container = kubeType.Spec.JobTemplate.Spec.Template.Spec.Containers
-	case *DaemonSet:
+	case *DaemonSetV1Beta1:
 		container = kubeType.Spec.Template.Spec.Containers
 	case *DaemonSetV1:
 		container = kubeType.Spec.Template.Spec.Containers
@@ -187,11 +187,11 @@ func getContainers(resource k8sRuntime.Object) (container []Container) {
 		container = kubeType.Spec.Template.Spec.Containers
 	case *DeploymentExtensionsV1Beta1:
 		container = kubeType.Spec.Template.Spec.Containers
-	case *Pod:
+	case *PodV1:
 		container = kubeType.Spec.Containers
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		container = kubeType.Spec.Template.Spec.Containers
-	case *StatefulSet:
+	case *StatefulSetV1Beta1:
 		container = kubeType.Spec.Template.Spec.Containers
 	case *StatefulSetV1:
 		container = kubeType.Spec.Template.Spec.Containers
@@ -201,9 +201,9 @@ func getContainers(resource k8sRuntime.Object) (container []Container) {
 
 func getPodAnnotations(resource k8sRuntime.Object) (annotations map[string]string) {
 	switch kubeType := resource.(type) {
-	case *CronJob:
+	case *CronJobV1Beta1:
 		annotations = kubeType.Spec.JobTemplate.Spec.Template.ObjectMeta.GetAnnotations()
-	case *DaemonSet:
+	case *DaemonSetV1Beta1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	case *DaemonSetV1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
@@ -215,11 +215,11 @@ func getPodAnnotations(resource k8sRuntime.Object) (annotations map[string]strin
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	case *DeploymentExtensionsV1Beta1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
-	case *Pod:
+	case *PodV1:
 		annotations = kubeType.ObjectMeta.GetAnnotations()
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
-	case *StatefulSet:
+	case *StatefulSetV1Beta1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	case *StatefulSetV1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()

--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -73,45 +73,45 @@ func kubeClientConfigLocal() (*rest.Config, error) {
 	return clientcmd.BuildConfigFromFlags("", rootConfig.kubeConfig)
 }
 
-func getDeployments(clientset *kubernetes.Clientset) *DeploymentList {
+func getDeployments(clientset *kubernetes.Clientset) *DeploymentListV1Beta1 {
 	deploymentClient := clientset.AppsV1beta1().Deployments(rootConfig.namespace)
-	deployments, err := deploymentClient.List(ListOptions{})
+	deployments, err := deploymentClient.List(ListOptionsV1{})
 	if err != nil {
 		log.Error(err)
 	}
 	return deployments
 }
 
-func getStatefulSets(clientset *kubernetes.Clientset) *StatefulSetList {
+func getStatefulSets(clientset *kubernetes.Clientset) *StatefulSetListV1Beta1 {
 	statefulSetClient := clientset.AppsV1beta1().StatefulSets(rootConfig.namespace)
-	statefulSets, err := statefulSetClient.List(ListOptions{})
+	statefulSets, err := statefulSetClient.List(ListOptionsV1{})
 	if err != nil {
 		log.Error(err)
 	}
 	return statefulSets
 }
 
-func getDaemonSets(clientset *kubernetes.Clientset) *DaemonSetList {
+func getDaemonSets(clientset *kubernetes.Clientset) *DaemonSetListV1Beta1 {
 	daemonSetClient := clientset.ExtensionsV1beta1().DaemonSets(rootConfig.namespace)
-	daemonSets, err := daemonSetClient.List(ListOptions{})
+	daemonSets, err := daemonSetClient.List(ListOptionsV1{})
 	if err != nil {
 		log.Error(err)
 	}
 	return daemonSets
 }
 
-func getPods(clientset *kubernetes.Clientset) *PodList {
+func getPods(clientset *kubernetes.Clientset) *PodListV1 {
 	podClient := clientset.CoreV1().Pods(rootConfig.namespace)
-	pods, err := podClient.List(ListOptions{})
+	pods, err := podClient.List(ListOptionsV1{})
 	if err != nil {
 		log.Error(err)
 	}
 	return pods
 }
 
-func getReplicationControllers(clientset *kubernetes.Clientset) *ReplicationControllerList {
+func getReplicationControllers(clientset *kubernetes.Clientset) *ReplicationControllerListV1 {
 	replicationControllerClient := clientset.CoreV1().ReplicationControllers(rootConfig.namespace)
-	replicationControllers, err := replicationControllerClient.List(ListOptions{})
+	replicationControllers, err := replicationControllerClient.List(ListOptionsV1{})
 	if err != nil {
 		log.Error(err)
 	}
@@ -120,7 +120,7 @@ func getReplicationControllers(clientset *kubernetes.Clientset) *ReplicationCont
 
 func getNetworkPolicies(clientset *kubernetes.Clientset) *networking.NetworkPolicyList {
 	netPolClient := clientset.NetworkingV1().NetworkPolicies(rootConfig.namespace)
-	netPols, err := netPolClient.List(ListOptions{})
+	netPols, err := netPolClient.List(ListOptionsV1{})
 	if err != nil {
 		log.Error(err)
 	}

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -39,7 +39,7 @@ func (limit *limitFlags) parseLimitFlags() {
 	}
 }
 
-func checkLimits(container Container, limits limitFlags, result *Result) {
+func checkLimits(container ContainerV1, limits limitFlags, result *Result) {
 	if container.Resources.Limits == nil {
 		occ := Occurrence{id: ErrorResourcesLimitsNil, kind: Warn, message: "Resource limit not set, please set it!"}
 		result.Occurrences = append(result.Occurrences, occ)
@@ -50,7 +50,7 @@ func checkLimits(container Container, limits limitFlags, result *Result) {
 	checkMemoryLimit(container, limits, result)
 }
 
-func checkCPULimit(container Container, limits limitFlags, result *Result) {
+func checkCPULimit(container ContainerV1, limits limitFlags, result *Result) {
 	cpu := container.Resources.Limits.Cpu()
 	if cpu == nil || cpu.IsZero() {
 		occ := Occurrence{id: ErrorResourcesLimitsCPUNil, kind: Warn, message: "CPU limit not set, please set it!"}
@@ -67,7 +67,7 @@ func checkCPULimit(container Container, limits limitFlags, result *Result) {
 	}
 }
 
-func checkMemoryLimit(container Container, limits limitFlags, result *Result) {
+func checkMemoryLimit(container ContainerV1, limits limitFlags, result *Result) {
 	memory := container.Resources.Limits.Memory()
 	if memory == nil || memory.IsZero() {
 		occ := Occurrence{id: ErrorResourcesLimitsMemoryNil, kind: Warn, message: "Memory limit not set, please set it!"}

--- a/cmd/networkPolicies.go
+++ b/cmd/networkPolicies.go
@@ -5,8 +5,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func checkNamespaceNetworkPolicies(netPols *NetworkPolicyList) {
-	badNetPols := []NetworkPolicy{}
+func checkNamespaceNetworkPolicies(netPols *NetworkPolicyListV1) {
+	badNetPols := []NetworkPolicyV1{}
 
 	for _, netPol := range netPols.Items {
 		for _, ingress := range netPol.Spec.Ingress {

--- a/cmd/privileged.go
+++ b/cmd/privileged.go
@@ -7,7 +7,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
-func checkPrivileged(container Container, result *Result) {
+func checkPrivileged(container ContainerV1, result *Result) {
 	if container.SecurityContext == nil || container.SecurityContext.Privileged == nil {
 		occ := Occurrence{
 			container: container.Name,

--- a/cmd/privileged_fixes.go
+++ b/cmd/privileged_fixes.go
@@ -3,7 +3,7 @@ package cmd
 import k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 
 func fixPrivileged(resource k8sRuntime.Object, occurrence Occurrence) k8sRuntime.Object {
-	var containers []Container
+	var containers []ContainerV1
 	for _, container := range getContainers(resource) {
 		if occurrence.container == container.Name {
 			container.SecurityContext.Privileged = newFalse()

--- a/cmd/readOnlyRootFilesystem.go
+++ b/cmd/readOnlyRootFilesystem.go
@@ -7,7 +7,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
-func checkReadOnlyRootFS(container Container, result *Result) {
+func checkReadOnlyRootFS(container ContainerV1, result *Result) {
 	if reason := result.Labels["audit.kubernetes.io/allow-read-only-root-filesystem-false"]; reason != "" {
 		if container.SecurityContext == nil || container.SecurityContext.ReadOnlyRootFilesystem == nil || *container.SecurityContext.ReadOnlyRootFilesystem == false {
 			occ := Occurrence{

--- a/cmd/readOnlyRootFilesystem_fixes.go
+++ b/cmd/readOnlyRootFilesystem_fixes.go
@@ -3,7 +3,7 @@ package cmd
 import k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 
 func fixReadOnlyRootFilesystem(resource k8sRuntime.Object, occurrence Occurrence) k8sRuntime.Object {
-	var containers []Container
+	var containers []ContainerV1
 	for _, container := range getContainers(resource) {
 		if occurrence.container == container.Name {
 			container.SecurityContext.ReadOnlyRootFilesystem = newTrue()

--- a/cmd/result.go
+++ b/cmd/result.go
@@ -83,12 +83,12 @@ func shouldLog(err int) (members []string) {
 	return
 }
 
-func (res *Result) allowedCaps() (allowed map[Capability]string) {
-	allowed = make(map[Capability]string)
+func (res *Result) allowedCaps() (allowed map[CapabilityV1]string) {
+	allowed = make(map[CapabilityV1]string)
 	for k, v := range res.Labels {
 		if strings.Contains(k, "audit.kubernetes.io/allow-capability-") {
 			capName := strings.Replace(strings.ToUpper(strings.TrimPrefix(k, "audit.kubernetes.io/allow-capability-")), "-", "_", -1)
-			allowed[Capability(capName)] = v
+			allowed[CapabilityV1(capName)] = v
 		}
 	}
 	return

--- a/cmd/runAsNonRoot.go
+++ b/cmd/runAsNonRoot.go
@@ -7,7 +7,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
-func checkRunAsNonRoot(container Container, result *Result) {
+func checkRunAsNonRoot(container ContainerV1, result *Result) {
 	if reason := result.Labels["audit.kubernetes.io/allow-run-as-root"]; reason != "" {
 		if container.SecurityContext == nil || container.SecurityContext.RunAsNonRoot == nil || *container.SecurityContext.RunAsNonRoot == false {
 			occ := Occurrence{

--- a/cmd/runAsNonRoot_fixes.go
+++ b/cmd/runAsNonRoot_fixes.go
@@ -3,7 +3,7 @@ package cmd
 import k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 
 func fixRunAsNonRoot(resource k8sRuntime.Object, occurrence Occurrence) k8sRuntime.Object {
-	var containers []Container
+	var containers []ContainerV1
 	for _, container := range getContainers(resource) {
 		if occurrence.container == container.Name {
 			container.SecurityContext.RunAsNonRoot = newTrue()

--- a/cmd/securitycontext_fixes.go
+++ b/cmd/securitycontext_fixes.go
@@ -3,10 +3,10 @@ package cmd
 import k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 
 func fixSecurityContextNil(resource k8sRuntime.Object) k8sRuntime.Object {
-	var containers []Container
+	var containers []ContainerV1
 	for _, container := range getContainers(resource) {
 		if container.SecurityContext == nil {
-			container.SecurityContext = &SecurityContext{Capabilities: &Capabilities{Drop: []Capability{}, Add: []Capability{}}}
+			container.SecurityContext = &SecurityContextV1{Capabilities: &CapabilitiesV1{Drop: []CapabilityV1{}, Add: []CapabilityV1{}}}
 		}
 		containers = append(containers, container)
 	}

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -92,14 +92,14 @@ func runAuditTestInNamespace(t *testing.T, namespace string, file string, functi
 }
 
 // NewPod returns a simple Pod resource
-func NewPod() *Pod {
+func NewPod() *PodV1 {
 	resources, err := getKubeResourcesManifest("../fixtures/pod.yml")
 	if err != nil {
 		return nil
 	}
 	for _, resource := range resources {
 		switch t := resource.(type) {
-		case *Pod:
+		case *PodV1:
 			return t
 		}
 	}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -2,102 +2,102 @@ package cmd
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	v1beta1 "k8s.io/api/apps/v1beta1"
-	v1beta2 "k8s.io/api/apps/v1beta2"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	networking "k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// CronJob is a type alias for the v1beta1 version of the k8s API.
-type CronJob = batchv1beta1.CronJob
+// CapabilitiesV1 is a type alias for the v1 version of the k8s API.
+type CapabilitiesV1 = apiv1.Capabilities
 
-// DaemonSet is a type alias for the v1beta1 version of the k8s API.
-type DaemonSet = extensionsv1beta1.DaemonSet
+// CapabilityV1 is a type alias for the v1 version of the k8s API.
+type CapabilityV1 = apiv1.Capability
 
-// DaemonSetV1 is a type alias for the v1 version of the k8s API.
-type DaemonSetV1 = appsv1.DaemonSet
+// ContainerV1 is a type alias for the v1 version of the k8s API.
+type ContainerV1 = apiv1.Container
 
-// NetworkPolicy is a type alias for the v1 version of the k8s API.
-type NetworkPolicy = networking.NetworkPolicy
-
-// Pod is a type alias for the v1 version of the k8s API.
-type Pod = apiv1.Pod
-
-// ReplicationController is a type alias for the v1 version of the k8s API.
-type ReplicationController = apiv1.ReplicationController
-
-// SecurityContext is a type alias for the v1 version of the k8s API.
-type SecurityContext = apiv1.SecurityContext
-
-// StatefulSet is a type alias for the v1beta1 version of the k8s API.
-type StatefulSet = v1beta1.StatefulSet
-
-// StatefulSetV1 is a type alias for the v1 version of the k8s apps API.
-type StatefulSetV1 = appsv1.StatefulSet
-
-// ObjectMeta is a type alias for the v1 version of the k8s API.
-type ObjectMeta = metav1.ObjectMeta
-
-// PodSpec is a type alias for the v1 version of the k8s API.
-type PodSpec = apiv1.PodSpec
-
-// DaemonSetList is a type alias for the v1beta1 version of the k8s API.
-type DaemonSetList = extensionsv1beta1.DaemonSetList
+// CronJobV1Beta1 is a type alias for the v1beta1 version of the k8s batch API.
+type CronJobV1Beta1 = batchv1beta1.CronJob
 
 // DaemonSetListV1 is a type alias for the v1 version of the k8s apps API.
 type DaemonSetListV1 = appsv1.DaemonSetList
 
-// DeploymentList is a type alias for the v1beta1 version of the k8s API.
-type DeploymentList = v1beta1.DeploymentList
+// DaemonSetListV1Beta1 is a type alias for the v1beta1 version of the k8s extensions API.
+type DaemonSetListV1Beta1 = extensionsv1beta1.DaemonSetList
+
+// DaemonSetV1 is a type alias for the v1 version of the k8s API.
+type DaemonSetV1 = appsv1.DaemonSet
+
+// DaemonSetV1Beta1 is a type alias for the v1beta1 version of the k8s extensions API.
+type DaemonSetV1Beta1 = extensionsv1beta1.DaemonSet
+
+// DeploymentExtensionsV1Beta1 is a type alias for the v1beta1 version of the k8s extensions API.
+type DeploymentExtensionsV1Beta1 = extensionsv1beta1.Deployment
 
 // DeploymentListV1 is a type alias for the v1 version of the k8s apps API.
 type DeploymentListV1 = appsv1.DeploymentList
 
-// NamespaceList is a type alias for the v1 version of the k8s API.
-type NamespaceList = apiv1.NamespaceList
-
-// NetworkPolicyList is a type alias for the v1 version of the k8s API.
-type NetworkPolicyList = networking.NetworkPolicyList
-
-// PodList is a type alias for the v1 version of the k8s API.
-type PodList = apiv1.PodList
-
-// ReplicationControllerList is a type alias for the v1 version of the k8s API.
-type ReplicationControllerList = apiv1.ReplicationControllerList
-
-// StatefulSetList is a type alias for the v1beta1 version of the k8s API.
-type StatefulSetList = v1beta1.StatefulSetList
-
-// StatefulSetListV1 is a type alias for the v1 version of the k8s apps API.
-type StatefulSetListV1 = appsv1.StatefulSetList
-
-// Capabilities is a type alias for the v1 version of the k8s API.
-type Capabilities = apiv1.Capabilities
-
-// Capability is a type alias for the v1 version of the k8s API.
-type Capability = apiv1.Capability
-
-// Container is a type alias for the v1 version of the k8s API.
-type Container = apiv1.Container
-
-// ListOptions is a type alias for the v1 version of the k8s API.
-type ListOptions = metav1.ListOptions
-
-// DeploymentV1Beta1 is a type alias for the v1beta1 version of the k8s API.
-type DeploymentV1Beta1 = v1beta1.Deployment
-
-// DeploymentV1Beta2 is a type alias for the v1beta2 version of the k8s API.
-type DeploymentV1Beta2 = v1beta2.Deployment
+// DeploymentListV1Beta1 is a type alias for the v1beta1 version of the k8s apps API.
+type DeploymentListV1Beta1 = appsv1beta1.DeploymentList
 
 // DeploymentV1 is a type alias for the v1 version of the k8s apps API.
 type DeploymentV1 = appsv1.Deployment
 
-// DeploymentExtensionsV1Beta1 is a type alias for the v1beta1 version of the k8s API.
-type DeploymentExtensionsV1Beta1 = extensionsv1beta1.Deployment
+// DeploymentV1Beta1 is a type alias for the v1beta1 version of the k8s apps API.
+type DeploymentV1Beta1 = appsv1beta1.Deployment
+
+// DeploymentV1Beta2 is a type alias for the v1beta2 version of the k8s apps API.
+type DeploymentV1Beta2 = appsv1beta2.Deployment
+
+// ListOptionsV1 is a type alias for the v1 version of the k8s meta API.
+type ListOptionsV1 = metav1.ListOptions
+
+// NamespaceListV1 is a type alias for the v1 version of the k8s API.
+type NamespaceListV1 = apiv1.NamespaceList
+
+// NetworkPolicyListV1 is a type alias for the v1 version of the k8s networking API.
+type NetworkPolicyListV1 = networkingv1.NetworkPolicyList
+
+// NetworkPolicyV1 is a type alias for the v1 version of the k8s API.
+type NetworkPolicyV1 = networkingv1.NetworkPolicy
+
+// ObjectMetaV1 is a type alias for the v1 version of the k8s API.
+type ObjectMetaV1 = metav1.ObjectMeta
+
+// PodListV1 is a type alias for the v1 version of the k8s API.
+type PodListV1 = apiv1.PodList
+
+// PodSpecV1 is a type alias for the v1 version of the k8s API.
+type PodSpecV1 = apiv1.PodSpec
+
+// PodV1 is a type alias for the v1 version of the k8s API.
+type PodV1 = apiv1.Pod
+
+// ReplicationControllerListV1 is a type alias for the v1 version of the k8s API.
+type ReplicationControllerListV1 = apiv1.ReplicationControllerList
+
+// ReplicationControllerV1 is a type alias for the v1 version of the k8s API.
+type ReplicationControllerV1 = apiv1.ReplicationController
+
+// SecurityContextV1 is a type alias for the v1 version of the k8s API.
+type SecurityContextV1 = apiv1.SecurityContext
+
+// StatefulSetListV1 is a type alias for the v1 version of the k8s apps API.
+type StatefulSetListV1 = appsv1.StatefulSetList
+
+// StatefulSetListV1Beta1 is a type alias for the v1beta1 version of the k8s apps API.
+type StatefulSetListV1Beta1 = appsv1beta1.StatefulSetList
+
+// StatefulSetV1 is a type alias for the v1 version of the k8s apps API.
+type StatefulSetV1 = appsv1.StatefulSet
+
+// StatefulSetV1Beta1 is a type alias for the v1beta1 version of the k8s API.
+type StatefulSetV1Beta1 = appsv1beta1.StatefulSet
 
 // Metadata holds metadata for a potential security issue.
 type Metadata = map[string]string
@@ -105,9 +105,9 @@ type Metadata = map[string]string
 // IsSupportedResourceType returns true if obj is a supported Kubernetes resource type
 func IsSupportedResourceType(obj runtime.Object) bool {
 	switch obj.(type) {
-	case *CronJob, *DaemonSet, *NetworkPolicy, *Pod, *ReplicationController, *StatefulSet,
-		*DaemonSetList, *DeploymentList, *NamespaceList, *NetworkPolicyList, *PodList, *ReplicationControllerList,
-		*StatefulSetList, *DeploymentV1Beta1, *DeploymentV1Beta2, *DeploymentExtensionsV1Beta1,
+	case *CronJobV1Beta1, *DaemonSetV1Beta1, *NetworkPolicyV1, *PodV1, *ReplicationControllerV1, *StatefulSetV1Beta1,
+		*DaemonSetListV1Beta1, *DeploymentListV1Beta1, *NamespaceListV1, *NetworkPolicyListV1, *PodListV1, *ReplicationControllerListV1,
+		*StatefulSetListV1Beta1, *DeploymentV1Beta1, *DeploymentV1Beta2, *DeploymentExtensionsV1Beta1,
 		*DeploymentListV1, *DeploymentV1, *DaemonSetV1, *StatefulSetListV1, *DaemonSetListV1, *StatefulSetV1:
 		return true
 	default:

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -48,12 +48,12 @@ func newResultFromResource(resource k8sRuntime.Object) (*Result, error) {
 	result := &Result{}
 
 	switch kubeType := resource.(type) {
-	case *CronJob:
+	case *CronJobV1Beta1:
 		result.KubeType = "cronjob"
 		result.Labels = kubeType.Spec.JobTemplate.Labels
 		result.Name = kubeType.Name
 		result.Namespace = kubeType.Namespace
-	case *DaemonSet:
+	case *DaemonSetV1Beta1:
 		result.KubeType = "daemonSet"
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
@@ -83,17 +83,17 @@ func newResultFromResource(resource k8sRuntime.Object) (*Result, error) {
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
 		result.Namespace = kubeType.Namespace
-	case *Pod:
+	case *PodV1:
 		result.KubeType = "pod"
 		result.Labels = kubeType.Labels
 		result.Name = kubeType.Name
 		result.Namespace = kubeType.Namespace
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		result.KubeType = "replicationController"
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
 		result.Namespace = kubeType.Namespace
-	case *StatefulSet:
+	case *StatefulSetV1Beta1:
 		result.KubeType = "statefulSet"
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
@@ -116,11 +116,11 @@ func newResultFromResourceWithServiceAccountInfo(resource k8sRuntime.Object) (*R
 	}
 
 	switch kubeType := resource.(type) {
-	case *CronJob:
+	case *CronJobV1Beta1:
 		result.DSA = kubeType.Spec.JobTemplate.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken
-	case *DaemonSet:
+	case *DaemonSetV1Beta1:
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
@@ -144,15 +144,15 @@ func newResultFromResourceWithServiceAccountInfo(resource k8sRuntime.Object) (*R
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
-	case *Pod:
+	case *PodV1:
 		result.DSA = kubeType.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.AutomountServiceAccountToken
-	case *ReplicationController:
+	case *ReplicationControllerV1:
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
-	case *StatefulSet:
+	case *StatefulSetV1Beta1:
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken


### PR DESCRIPTION
Adds the version to all of the kubernetes type aliases. If there is a conflict (ie. a type is present in the same version of two different groups), then the type name includes both the group and the version.