### PR TITLE
Audit all containers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -67,6 +67,19 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
+  digest = "1:f9f45f75f332e03fc7e9fe9188ea4e1ce4d14779ef34fa1b023da67518e36327"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = ""
+  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
   name = "github.com/google/gofuzz"
@@ -546,6 +559,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/go-test/deep",
+    "github.com/google/go-cmp/cmp",
     "github.com/hashicorp/go-version",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/cmd/allowPrivilegeEscalation.go
+++ b/cmd/allowPrivilegeEscalation.go
@@ -57,7 +57,6 @@ func auditAllowPrivilegeEscalation(resource Resource) (results []Result) {
 		checkAllowPrivilegeEscalation(container, result)
 		if len(result.Occurrences) > 0 {
 			results = append(results, *result)
-			break
 		}
 	}
 	return

--- a/cmd/autofix_test.go
+++ b/cmd/autofix_test.go
@@ -1,49 +1,10 @@
 package cmd
 
 import (
-	"bufio"
-	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func compareFiles(file1, file2 string) bool {
-	f1, err := os.Open(file1)
-	if err != nil {
-		return false
-	}
-
-	f2, err := os.Open(file2)
-	if err != nil {
-		return false
-	}
-
-	s1 := bufio.NewScanner(f1)
-	s2 := bufio.NewScanner(f2)
-
-	for s1.Scan() {
-		s2.Scan()
-		text1 := s1.Text()
-		text2 := s2.Text()
-		if text1 != text2 {
-			fmt.Printf("Files don't match here:\n%v\n%v\n\n", text1, text2)
-			return false
-		}
-	}
-	return true
-}
-
-func assertEqualWorkloads(assert *assert.Assertions, resource1, resource2 []Resource) {
-	tmpfile1, err := WriteToTmpFile(resource1[0])
-	assert.Nil(err)
-	defer os.Remove(tmpfile1)
-	tmpfile2, err := WriteToTmpFile(resource2[0])
-	assert.Nil(err)
-	defer os.Remove(tmpfile2)
-	assert.True(compareFiles(tmpfile1, tmpfile2))
-}
 
 func TestFixV1(t *testing.T) {
 	file := "../fixtures/autofix_v1.yml"

--- a/cmd/autofix_test.go
+++ b/cmd/autofix_test.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"bufio"
-	"bytes"
+	"fmt"
 	"os"
 	"testing"
 
@@ -25,7 +25,10 @@ func compareFiles(file1, file2 string) bool {
 
 	for s1.Scan() {
 		s2.Scan()
-		if !bytes.Equal(s1.Bytes(), s2.Bytes()) {
+		text1 := s1.Text()
+		text2 := s2.Text()
+		if text1 != text2 {
+			fmt.Printf("Files don't match here:\n%v\n%v\n\n", text1, text2)
 			return false
 		}
 	}
@@ -33,15 +36,13 @@ func compareFiles(file1, file2 string) bool {
 }
 
 func assertEqualWorkloads(assert *assert.Assertions, resource1, resource2 []Resource) {
-	file1 := "/tmp/dat1"
-	file2 := "/tmp/dat2"
-	err := WriteToFile(resource1[0], file1, false)
+	tmpfile1, err := WriteToTmpFile(resource1[0])
 	assert.Nil(err)
-	err = WriteToFile(resource2[0], file2, false)
+	defer os.Remove(tmpfile1)
+	tmpfile2, err := WriteToTmpFile(resource2[0])
 	assert.Nil(err)
-	assert.True(compareFiles(file1, file2))
-	os.Remove(file1)
-	os.Remove(file2)
+	defer os.Remove(tmpfile2)
+	assert.True(compareFiles(tmpfile1, tmpfile2))
 }
 
 func TestFixV1(t *testing.T) {

--- a/cmd/autofix_test.go
+++ b/cmd/autofix_test.go
@@ -1,12 +1,48 @@
 package cmd
 
 import (
+	"bufio"
+	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/go-test/deep"
 )
+
+func compareFiles(file1, file2 string) bool {
+	f1, err := os.Open(file1)
+	if err != nil {
+		return false
+	}
+
+	f2, err := os.Open(file2)
+	if err != nil {
+		return false
+	}
+
+	s1 := bufio.NewScanner(f1)
+	s2 := bufio.NewScanner(f2)
+
+	for s1.Scan() {
+		s2.Scan()
+		if !bytes.Equal(s1.Bytes(), s2.Bytes()) {
+			return false
+		}
+	}
+	return true
+}
+
+func assertEqualWorkloads(assert *assert.Assertions, resource1, resource2 []Resource) {
+	file1 := "/tmp/dat1"
+	file2 := "/tmp/dat2"
+	err := WriteToFile(resource1[0], file1, false)
+	assert.Nil(err)
+	err = WriteToFile(resource2[0], file2, false)
+	assert.Nil(err)
+	assert.True(compareFiles(file1, file2))
+	os.Remove(file1)
+	os.Remove(file2)
+}
 
 func TestFixV1(t *testing.T) {
 	file := "../fixtures/autofix_v1.yml"
@@ -17,7 +53,7 @@ func TestFixV1(t *testing.T) {
 	fixedResources := fix(resources)
 	correctlyFixedResources, err := getKubeResourcesManifest(fileFixed)
 	assert.Nil(err)
-	assert.Nil(deep.Equal(correctlyFixedResources, fixedResources))
+	assertEqualWorkloads(assert, correctlyFixedResources, fixedResources)
 }
 
 func TestFixV1Beta1(t *testing.T) {
@@ -29,5 +65,5 @@ func TestFixV1Beta1(t *testing.T) {
 	fixedResources := fix(resources)
 	correctlyFixedResources, err := getKubeResourcesManifest(fileFixed)
 	assert.Nil(err)
-	assert.Nil(deep.Equal(correctlyFixedResources, fixedResources))
+	assertEqualWorkloads(assert, correctlyFixedResources, fixedResources)
 }

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -77,7 +77,6 @@ func auditImages(image imgFlags, resource Resource) (results []Result) {
 		checkImage(container, image, result)
 		if len(result.Occurrences) > 0 {
 			results = append(results, *result)
-			break
 		}
 	}
 	return

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -96,7 +96,6 @@ func auditLimits(limits limitFlags, resource Resource) (results []Result) {
 		checkLimits(container, limits, result)
 		if len(result.Occurrences) > 0 {
 			results = append(results, *result)
-			break
 		}
 	}
 	return

--- a/cmd/privileged.go
+++ b/cmd/privileged.go
@@ -56,7 +56,6 @@ func auditPrivileged(resource Resource) (results []Result) {
 		checkPrivileged(container, result)
 		if len(result.Occurrences) > 0 {
 			results = append(results, *result)
-			break
 		}
 	}
 	return

--- a/cmd/readOnlyRootFilesystem.go
+++ b/cmd/readOnlyRootFilesystem.go
@@ -57,7 +57,6 @@ func auditReadOnlyRootFS(resource Resource) (results []Result) {
 		checkReadOnlyRootFS(container, result)
 		if len(result.Occurrences) > 0 {
 			results = append(results, *result)
-			break
 		}
 	}
 	return

--- a/cmd/runAsNonRoot.go
+++ b/cmd/runAsNonRoot.go
@@ -57,7 +57,6 @@ func auditRunAsNonRoot(resource Resource) (results []Result) {
 		checkRunAsNonRoot(container, result)
 		if len(result.Occurrences) > 0 {
 			results = append(results, *result)
-			break
 		}
 	}
 	return

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -146,7 +146,7 @@ func WriteToTmpFile(decode Resource) (string, error) {
 	return tmpfile.Name(), nil
 }
 
-func compareFiles(file1, file2 string) bool {
+func compareTextFiles(file1, file2 string) bool {
 	f1, err := os.Open(file1)
 	if err != nil {
 		return false
@@ -179,5 +179,5 @@ func assertEqualWorkloads(assert *assert.Assertions, resource1, resource2 []Reso
 	tmpfile2, err := WriteToTmpFile(resource2[0])
 	assert.Nil(err)
 	defer os.Remove(tmpfile2)
-	assert.True(compareFiles(tmpfile1, tmpfile2))
+	assert.True(compareTextFiles(tmpfile1, tmpfile2))
 }

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bufio"
+	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -118,7 +121,7 @@ func assertEqualYaml(fileToFix string, fileFixed string, auditFunc func(resource
 }
 
 // WriteToTmpFile writes a single resource to a tmpfile, you are responsible
-// for closing the file afterwards, that's why the function returns the file
+// for deleting the file afterwards, that's why the function returns the file
 // name.
 func WriteToTmpFile(decode Resource) (string, error) {
 	info, _ := k8sRuntime.SerializerInfoForMediaType(scheme.Codecs.SupportedMediaTypes(), "application/yaml")
@@ -141,4 +144,40 @@ func WriteToTmpFile(decode Resource) (string, error) {
 		return "", err
 	}
 	return tmpfile.Name(), nil
+}
+
+func compareFiles(file1, file2 string) bool {
+	f1, err := os.Open(file1)
+	if err != nil {
+		return false
+	}
+
+	f2, err := os.Open(file2)
+	if err != nil {
+		return false
+	}
+
+	s1 := bufio.NewScanner(f1)
+	s2 := bufio.NewScanner(f2)
+
+	for s1.Scan() {
+		s2.Scan()
+		text1 := s1.Text()
+		text2 := s2.Text()
+		if text1 != text2 {
+			fmt.Printf("Files don't match here:\n%v\n%v\n\n", text1, text2)
+			return false
+		}
+	}
+	return true
+}
+
+func assertEqualWorkloads(assert *assert.Assertions, resource1, resource2 []Resource) {
+	tmpfile1, err := WriteToTmpFile(resource1[0])
+	assert.Nil(err)
+	defer os.Remove(tmpfile1)
+	tmpfile2, err := WriteToTmpFile(resource2[0])
+	assert.Nil(err)
+	defer os.Remove(tmpfile2)
+	assert.True(compareFiles(tmpfile1, tmpfile2))
 }


### PR DESCRIPTION
This fixes #141 

Turns out if you `break` out of your loop then you never get shit done 🙂 

Added a regression test. Turns out: deep equal from `deep` doesn't catch the difference, deep equal from `reflect` complains that they are not equal, so I serialize them, write them to file and compare the file contents.