### PR TITLE
Remove unused go-cmp from Gopkg.lock.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -67,19 +67,6 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
-  digest = "1:f9f45f75f332e03fc7e9fe9188ea4e1ce4d14779ef34fa1b023da67518e36327"
-  name = "github.com/google/go-cmp"
-  packages = [
-    "cmp",
-    "cmp/internal/diff",
-    "cmp/internal/function",
-    "cmp/internal/value",
-  ]
-  pruneopts = ""
-  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
-  version = "v0.2.0"
-
-[[projects]]
   branch = "master"
   digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
   name = "github.com/google/gofuzz"
@@ -559,7 +546,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/go-test/deep",
-    "github.com/google/go-cmp/cmp",
     "github.com/hashicorp/go-version",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",


### PR DESCRIPTION
The package go-cmp is no longer used, but it was still in Gopkg.lock. This removes it so that the state will be clean for the next release.