### PR TITLE
add replacement for DSA to SA

### DIFF
--- a/cmd/automountServiceAccountToken_fixes_test.go
+++ b/cmd/automountServiceAccountToken_fixes_test.go
@@ -11,6 +11,47 @@ func TestFixServiceAccountTokenDeprecatedV1(t *testing.T) {
 	}
 }
 
+func TestFixServiceAccountTokenDeprecatedV2(t *testing.T) {
+	assert, resources := FixTestSetupMultipleResources(t, "service_account_token_deprecated_multiple_resources_v1.yml", auditAutomountServiceAccountToken)
+	for index := range resources {
+		switch t := resources[index].(type) {
+		case *CronJobV1Beta1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.JobTemplate.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *DaemonSetV1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *DaemonSetV1Beta1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *DeploymentExtensionsV1Beta1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *DeploymentV1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *DeploymentV1Beta1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *DeploymentV1Beta2:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *PodV1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.DeprecatedServiceAccount)
+		case *ReplicationControllerV1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *StatefulSetV1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *StatefulSetV1Beta1:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		}
+	}
+}
+
 func TestFixServiceAccountTokenTrueAndNoNameV1(t *testing.T) {
 	assert, resource := FixTestSetup(t, "service_account_token_true_and_no_name_v1.yml", auditAutomountServiceAccountToken)
 	switch typ := resource.(type) {

--- a/cmd/automountServiceAccountToken_fixes_test.go
+++ b/cmd/automountServiceAccountToken_fixes_test.go
@@ -6,6 +6,7 @@ func TestFixServiceAccountTokenDeprecatedV1(t *testing.T) {
 	assert, resource := FixTestSetup(t, "service_account_token_deprecated_v1.yml", auditAutomountServiceAccountToken)
 	switch typ := resource.(type) {
 	case *ReplicationControllerV1:
+		assert.Equal("fakeDeprecatedServiceAccount", typ.Spec.Template.Spec.ServiceAccountName)
 		assert.Equal("", typ.Spec.Template.Spec.DeprecatedServiceAccount)
 	}
 }

--- a/cmd/k8sruntime_util.go
+++ b/cmd/k8sruntime_util.go
@@ -51,36 +51,47 @@ func setContainers(resource Resource, containers []ContainerV1) Resource {
 func disableDSA(resource Resource) Resource {
 	switch t := resource.(type) {
 	case *CronJobV1Beta1:
+		t.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName = t.Spec.JobTemplate.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.JobTemplate.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DaemonSetV1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DaemonSetV1Beta1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DeploymentExtensionsV1Beta1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DeploymentV1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DeploymentV1Beta1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DeploymentV1Beta2:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *PodV1:
+		t.Spec.ServiceAccountName = t.Spec.DeprecatedServiceAccount
 		t.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *ReplicationControllerV1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *StatefulSetV1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *StatefulSetV1Beta1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	}

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -41,10 +41,11 @@ func FixTestSetupMultipleResources(t *testing.T, file string, auditFunction func
 	file = filepath.Join(path, file)
 	resources, err := getKubeResourcesManifest(file)
 	assert.Nil(err)
-	results := getResults(resources, auditFunction)
-	for index := range resources {
-		resource := resources[index]
-		fixedResources = append(fixedResources, fixPotentialSecurityIssue(resource, results[index]))
+	for _, resource := range resources {
+		results := getResults([]Resource{resource}, auditFunction)
+		for _, result := range results {
+			fixedResources = append(fixedResources, fixPotentialSecurityIssue(resource, result))
+		}
 	}
 	return assert, fixedResources
 }

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -44,8 +44,9 @@ func FixTestSetupMultipleResources(t *testing.T, file string, auditFunction func
 	for _, resource := range resources {
 		results := getResults([]Resource{resource}, auditFunction)
 		for _, result := range results {
-			fixedResources = append(fixedResources, fixPotentialSecurityIssue(resource, result))
+			resource = fixPotentialSecurityIssue(resource, result)
 		}
+		fixedResources = append(fixedResources, resource)
 	}
 	return assert, fixedResources
 }

--- a/cmd/test_util.go
+++ b/cmd/test_util.go
@@ -34,6 +34,21 @@ func FixTestSetup(t *testing.T, file string, auditFunction func(Resource) []Resu
 	return assert, fixPotentialSecurityIssue(resource, result)
 }
 
+// FixTestSetupMultipleResources allows kubeaudit to be used programmatically instead of via the shell for multiple Resources. It is intended to be used for testing.
+func FixTestSetupMultipleResources(t *testing.T, file string, auditFunction func(Resource) []Result) (*assert.Assertions, []Resource) {
+	var fixedResources []Resource
+	assert := assert.New(t)
+	file = filepath.Join(path, file)
+	resources, err := getKubeResourcesManifest(file)
+	assert.Nil(err)
+	results := getResults(resources, auditFunction)
+	for index := range resources {
+		resource := resources[index]
+		fixedResources = append(fixedResources, fixPotentialSecurityIssue(resource, results[index]))
+	}
+	return assert, fixedResources
+}
+
 func runAuditTest(t *testing.T, file string, function interface{}, errCodes []int, argStr ...string) (results []Result) {
 	assert := assert.New(t)
 	file = filepath.Join(path, file)

--- a/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
+++ b/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
@@ -1,6 +1,26 @@
 ---
-apiVersion: v1
-kind: ReplicationController
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccount: fakeDeprecatedServiceAccount
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure
+---
+apiVersion: apps/v1
+kind: DaemonSet
 metadata:
   creationTimestamp: null
   name: fakeReplicationControllerASAT1
@@ -19,8 +39,28 @@ spec:
 status:
   replicas: 0
 ---
-apiVersion: apps/v1
+apiVersion: extensionsv1beta1
 kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
+apiVersion: extensionsv1beta1
+kind: Deployment
 metadata:
   creationTimestamp: null
   name: fakeReplicationControllerASAT1
@@ -79,6 +119,26 @@ spec:
 status:
   replicas: 0
 ---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -96,22 +156,22 @@ spec:
         memory: "100Mi"
     command: ["stress"]
 ---
-apiVersion: batch/v1beta1
-kind: CronJob
+apiVersion: v1
+kind: ReplicationController
 metadata:
-  name: hello
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
 spec:
-  schedule: "*/1 * * * *"
-  jobTemplate:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
     spec:
-      template:
-        spec:
-          serviceAccount: fakeDeprecatedServiceAccount
-          containers:
-          - name: hello
-            image: busybox
-            args:
-            - /bin/sh
-            - -c
-            - date; echo Hello from the Kubernetes cluster
-          restartPolicy: OnFailure
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0

--- a/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
+++ b/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
@@ -59,26 +59,6 @@ spec:
 status:
   replicas: 0
 ---
-apiVersion: apps/v1beta
-kind: DaemonSet
-metadata:
-  creationTimestamp: null
-  name: fakeReplicationControllerASAT1
-  namespace: fakeReplicationControllerASAT
-spec:
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        apps: fakeAutomountServiceAccountToken
-    spec:
-      containers:
-      - name: fakeContainerASAT
-        resources: {}
-      serviceAccount: fakeDeprecatedServiceAccount
-status:
-  replicas: 0
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
+++ b/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
@@ -1,0 +1,117 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: memory-demo
+  namespace: mem-example
+spec:
+  serviceAccount: fakeDeprecatedServiceAccount
+  containers:
+  - name: memory-demo-ctr
+    image: polinux/stress
+    resources:
+      limits:
+        memory: "200Mi"
+      requests:
+        memory: "100Mi"
+    command: ["stress"]
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccount: fakeDeprecatedServiceAccount
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
+++ b/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
@@ -39,7 +39,7 @@ spec:
 status:
   replicas: 0
 ---
-apiVersion: extensionsv1beta1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   creationTimestamp: null
@@ -59,8 +59,8 @@ spec:
 status:
   replicas: 0
 ---
-apiVersion: extensionsv1beta1
-kind: Deployment
+apiVersion: apps/v1beta
+kind: DaemonSet
 metadata:
   creationTimestamp: null
   name: fakeReplicationControllerASAT1
@@ -80,6 +80,66 @@ status:
   replicas: 0
 ---
 apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+status:
+  replicas: 0
+---
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->
<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Kind words by Jon -

If serviceAccount is present, it should assume that serviceAccountName is also set and present because it's an alias (deprecated)

if there is no serviceAccount[Name] specified, it assumes `default` and uses the `default` SA token, which is not desirable in most multi-tenant circumstances, so automountServiceAccountToken: false should then be applied (edited) 
To use a non-default service account, simply set the spec.serviceAccountName field of a pod to the name of the service account you wish to use.
so realistically, if serviceAccount != default, then it should replace it with serviceAccountName instead
if it is default, remove it and add automount false

Fixes # (issue)
closes #157 
##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Tests -
- [x] TestFixServiceAccountTokenDeprecatedV1

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
