### PR TITLE
Fix default SA name bug

### DIFF
--- a/cmd/automountServiceAccountToken.go
+++ b/cmd/automountServiceAccountToken.go
@@ -38,7 +38,7 @@ func checkAutomountServiceAccountToken(result *Result) {
 		return
 	}
 
-	if result.Token != nil && *result.Token && result.SA == "" {
+	if result.Token != nil && *result.Token && (result.SA == "" || result.SA == "default") {
 		// automountServiceAccountToken = true, and serviceAccountName is blank (default: default)
 		occ := Occurrence{
 			id:      ErrorAutomountServiceAccountTokenTrueAndNoName,

--- a/cmd/automountServiceAccountToken.go
+++ b/cmd/automountServiceAccountToken.go
@@ -38,7 +38,8 @@ func checkAutomountServiceAccountToken(result *Result) {
 		return
 	}
 
-	if result.Token != nil && *result.Token && (result.SA == "" || result.SA == "default") {
+	if result.Token != nil && *result.Token &&
+		(result.SA == "" || result.SA == "default") {
 		// automountServiceAccountToken = true, and serviceAccountName is blank (default: default)
 		occ := Occurrence{
 			id:      ErrorAutomountServiceAccountTokenTrueAndNoName,

--- a/cmd/automountServiceAccountToken_test.go
+++ b/cmd/automountServiceAccountToken_test.go
@@ -21,3 +21,7 @@ func TestServiceAccountTokenTrueAllowedV1(t *testing.T) {
 func TestServiceAccountTokenMisconfiguredAllowV1(t *testing.T) {
 	runAuditTest(t, "service_account_token_misconfigured_allow_v1.yml", auditAutomountServiceAccountToken, []int{ErrorMisconfiguredKubeauditAllow})
 }
+
+func TestServiceAccountTokenTrueAndDefaultNameV1(t *testing.T) {
+	runAuditTest(t, "service_account_token_true_and_default_name_v1.yml", auditAutomountServiceAccountToken, []int{ErrorAutomountServiceAccountTokenTrueAndNoName})
+}

--- a/fixtures/service_account_token_true_and_default_name_v1.yml
+++ b/fixtures/service_account_token_true_and_default_name_v1.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT2
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: default
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+status:
+  replicas: 0


### PR DESCRIPTION

##### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Ref #168, When `automountServiceAccountToken` is set to true and `serviceAccountName` is set to be `default` kubeaudit didn't throw an error as it should, this issue has been addressed in this PR.

Fixes # (issue)
closes #168 
##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
##### How Has This Been Tested?

- [x] TestServiceAccountTokenTrueAndDefaultNameV1

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
