### PR TITLE
add docs on installing via GoFish

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ or
 
 - renaming the binary to `kubectl-audit` and having it available in your path.
 
+#### GoFish
 
+You can also choose to install kubeaudit using [GoFish](https://gofi.sh/). It will also install kubeaudit as a kubectl plugin so it can be invoked with either `kubeaudit` or `kubectl audit` as mentioned above.
+
+To install, run `gofish install kubeaudit`.
+
+You can install gofish [following the instructions](https://gofi.sh/#install) for your Operating System.
 
 <a name="general" />
 
@@ -311,7 +317,7 @@ WARN[0000] Memory limit exceeded, it is set to 512Mi but it must not exceed 125M
 
 ## Audit AppArmor
 
-It checks that AppArmor is enabled for all containers by making sure the following annotation exists on the pod. 
+It checks that AppArmor is enabled for all containers by making sure the following annotation exists on the pod.
 There must be an annotation for each container in the pod:
 
 ```
@@ -337,8 +343,8 @@ ERRO[0000] AppArmor disabled. Annotation=container.apparmor.security.beta.kubern
 
 ## Audit Seccomp
 
-It checks that Seccomp is enabled for all containers by making sure one or both of the following annotations exists 
-on the pod. If no pod annotation is used, then there must be an annotation for each container. Container annotations 
+It checks that Seccomp is enabled for all containers by making sure one or both of the following annotations exists
+on the pod. If no pod annotation is used, then there must be an annotation for each container. Container annotations
 override the pod annotation:
 
 ```
@@ -349,7 +355,7 @@ seccomp.security.alpha.kubernetes.io/pod: <profile>
 container.seccomp.security.alpha.kubernetes.io/<container name>: <profile>
 ```
 
-where profile can be "runtime/default" or start with "localhost/" to be considered valid. "docker/default" is 
+where profile can be "runtime/default" or start with "localhost/" to be considered valid. "docker/default" is
 deprecated and will show a warning. It should be replaced with "runtime/default".
 
 If the Seccomp annotation is missing:


### PR DESCRIPTION
Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>

##### Description

As of https://github.com/fishworks/fish-food/pull/121, kubeaudit is installable via [GoFish](https://gofi.sh/). I'm the maintainer of GoFish and I'm also happy to maintain the package from GoFish's side, but the code's all open source.

##### How Has This Been Tested?

To install:

```
><> gofish update
==> Rigs updated!
NAME                          
github.com/fishworks/fish-food

🐠  rigs updated in 1.359322726s
><> gofish install kubeaudit
==> Installing kubeaudit...
🐠  kubeaudit 0.4.1: installed in 109.548424ms
><> kubeaudit --help
kubeaudit is a program that checks security settings on your Kubernetes clusters.
```

To upgrade, use either:

```
><> gofish upgrade
><> gofish upgrade kubeaudit
```

##### Checklist:

- [x] I have :tophat: my changes
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation