### PR TITLE
Support DaemonSet apps/v1beta2

### DIFF
--- a/cmd/automountServiceAccountToken_fixes_test.go
+++ b/cmd/automountServiceAccountToken_fixes_test.go
@@ -24,6 +24,9 @@ func TestFixServiceAccountTokenDeprecatedV2(t *testing.T) {
 		case *DaemonSetV1Beta1:
 			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
 			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
+		case *DaemonSetV1Beta2:
+			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
 		case *DeploymentExtensionsV1Beta1:
 			assert.Equal("fakeDeprecatedServiceAccount", t.Spec.Template.Spec.ServiceAccountName)
 			assert.Equal("", t.Spec.Template.Spec.DeprecatedServiceAccount)
@@ -69,6 +72,8 @@ func TestFixServiceAccountTokenTrueAndNoNameV2(t *testing.T) {
 		case *DaemonSetV1:
 			assert.False(*t.Spec.Template.Spec.AutomountServiceAccountToken)
 		case *DaemonSetV1Beta1:
+			assert.False(*t.Spec.Template.Spec.AutomountServiceAccountToken)
+		case *DaemonSetV1Beta2:
 			assert.False(*t.Spec.Template.Spec.AutomountServiceAccountToken)
 		case *DeploymentExtensionsV1Beta1:
 			assert.False(*t.Spec.Template.Spec.AutomountServiceAccountToken)

--- a/cmd/k8sruntime_util.go
+++ b/cmd/k8sruntime_util.go
@@ -20,6 +20,9 @@ func setContainers(resource Resource, containers []ContainerV1) Resource {
 	case *DaemonSetV1Beta1:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
+	case *DaemonSetV1Beta2:
+		t.Spec.Template.Spec.Containers = containers
+		return t.DeepCopyObject()
 	case *DeploymentExtensionsV1Beta1:
 		t.Spec.Template.Spec.Containers = containers
 		return t.DeepCopyObject()
@@ -71,6 +74,10 @@ func disableDSA(resource Resource) Resource {
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
 	case *DaemonSetV1Beta1:
+		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
+		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
+		return t.DeepCopyObject()
+	case *DaemonSetV1Beta2:
 		t.Spec.Template.Spec.ServiceAccountName = t.Spec.Template.Spec.DeprecatedServiceAccount
 		t.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		return t.DeepCopyObject()
@@ -127,6 +134,9 @@ func setASAT(resource Resource, b bool) Resource {
 	case *DaemonSetV1Beta1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
+	case *DaemonSetV1Beta2:
+		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
+		return t.DeepCopyObject()
 	case *DeploymentExtensionsV1Beta1:
 		t.Spec.Template.Spec.AutomountServiceAccountToken = boolean
 		return t.DeepCopyObject()
@@ -166,6 +176,9 @@ func setPodAnnotations(resource Resource, annotations map[string]string) Resourc
 	case *DaemonSetV1Beta1:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
+	case *DaemonSetV1Beta2:
+		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
+		return kubeType.DeepCopyObject()
 	case *DeploymentExtensionsV1Beta1:
 		kubeType.Spec.Template.ObjectMeta.SetAnnotations(annotations)
 		return kubeType.DeepCopyObject()
@@ -201,6 +214,8 @@ func getContainers(resource Resource) (container []ContainerV1) {
 	case *DaemonSetV1:
 		container = kubeType.Spec.Template.Spec.Containers
 	case *DaemonSetV1Beta1:
+		container = kubeType.Spec.Template.Spec.Containers
+	case *DaemonSetV1Beta2:
 		container = kubeType.Spec.Template.Spec.Containers
 	case *DeploymentExtensionsV1Beta1:
 		container = kubeType.Spec.Template.Spec.Containers
@@ -239,6 +254,8 @@ func getPodAnnotations(resource Resource) (annotations map[string]string) {
 	case *DaemonSetV1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	case *DaemonSetV1Beta1:
+		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
+	case *DaemonSetV1Beta2:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()
 	case *DeploymentExtensionsV1Beta1:
 		annotations = kubeType.Spec.Template.ObjectMeta.GetAnnotations()

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -33,6 +33,9 @@ type DaemonSetV1 = appsv1.DaemonSet
 // DaemonSetV1Beta1 is a type alias for the v1beta1 version of the k8s extensions API.
 type DaemonSetV1Beta1 = extensionsv1beta1.DaemonSet
 
+// DaemonSetV1Beta2 is a type alias for the v1beta2 version of the k8s extensions API.
+type DaemonSetV1Beta2 = appsv1beta2.DaemonSet
+
 // DeploymentExtensionsV1Beta1 is a type alias for the v1beta1 version of the k8s extensions API.
 type DeploymentExtensionsV1Beta1 = extensionsv1beta1.Deployment
 
@@ -106,7 +109,7 @@ type UnsupportedType = apiv1.Binding
 func IsSupportedResourceType(obj Resource) bool {
 	switch obj.(type) {
 	case *CronJobV1Beta1,
-		*DaemonSetListV1, *DaemonSetV1, *DaemonSetV1Beta1,
+		*DaemonSetListV1, *DaemonSetV1, *DaemonSetV1Beta1, *DaemonSetV1Beta2,
 		*DeploymentExtensionsV1Beta1, *DeploymentV1, *DeploymentV1Beta1, *DeploymentV1Beta2, *DeploymentListV1,
 		*NamespaceListV1, *NamespaceV1,
 		*NetworkPolicyListV1, *NetworkPolicyV1,

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -54,6 +54,11 @@ func newResultFromResource(resource Resource) (*Result, error, error) {
 		result.Labels = kubeType.Spec.Template.Labels
 		result.Name = kubeType.Name
 		result.Namespace = kubeType.Namespace
+	case *DaemonSetV1Beta2:
+		result.KubeType = "daemonSet"
+		result.Labels = kubeType.Spec.Template.Labels
+		result.Name = kubeType.Name
+		result.Namespace = kubeType.Namespace
 	case *DeploymentExtensionsV1Beta1:
 		result.KubeType = "deployment"
 		result.Labels = kubeType.Spec.Template.Labels
@@ -120,6 +125,10 @@ func newResultFromResourceWithServiceAccountInfo(resource Resource) (*Result, er
 		result.SA = kubeType.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.JobTemplate.Spec.Template.Spec.AutomountServiceAccountToken
 	case *DaemonSetV1Beta1:
+		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
+		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
+		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken
+	case *DaemonSetV1Beta2:
 		result.DSA = kubeType.Spec.Template.Spec.DeprecatedServiceAccount
 		result.SA = kubeType.Spec.Template.Spec.ServiceAccountName
 		result.Token = kubeType.Spec.Template.Spec.AutomountServiceAccountToken

--- a/fixtures/apparmor_annotation_missing_multiple_resources_v1.yml
+++ b/fixtures/apparmor_annotation_missing_multiple_resources_v1.yml
@@ -44,6 +44,22 @@ spec:
 status:
   replicas: 0
 ---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: fakeReplicationController1
+  namespace: fakeReplicationController
+spec:
+  template:
+    metadata:
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainer
+status:
+  replicas: 0
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
+++ b/fixtures/service_account_token_deprecated_multiple_resources_v1.yml
@@ -39,6 +39,24 @@ spec:
 status:
   replicas: 0
 ---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      serviceAccount: fakeDeprecatedServiceAccount
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:

--- a/fixtures/service_account_token_true_and_no_name_multiple_resources_v1.yml
+++ b/fixtures/service_account_token_true_and_no_name_multiple_resources_v1.yml
@@ -59,6 +59,26 @@ spec:
 status:
   replicas: 0
 ---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  name: fakeReplicationControllerASAT1
+  namespace: fakeReplicationControllerASAT
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        apps: fakeAutomountServiceAccountToken
+    spec:
+      containers:
+      - name: fakeContainerASAT
+        resources: {}
+      automountServiceAccountToken: true
+status:
+  replicas: 0
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
##### Description
This PR add's support for DaemonSet apps/v1beta2 resource - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#daemonset-v1beta2-apps

Fixes # (issue)
closes #183 
##### Type of change

- [x] Bug fix :bug:
##### How Has This Been Tested?

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
