### PR TITLE
Namespace Network Policy Overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ spec:
 ```
 
 `kubeaudit` can also skip a specific audit for all network policies associated with a namespace resource
-by adding a namespace override label. For example if you use `kubeaudit` to ignore `allow-non-default-deny-egress-network-policy` check for a namespace named `namespaceName1` you can add the following label to the namespace:
+by adding a namespace override label. For example, if you use `kubeaudit` to ignore the `allow-non-default-deny-egress-network-policy` check for the namespace `namespaceName1` you can add the following label to the namespace:
 
 ```sh
 metadata:

--- a/README.md
+++ b/README.md
@@ -437,8 +437,8 @@ metadata:
 - [audit.kubernetes.io/pod/allow-automount-service-account-token](#sat_label)
 - [audit.kubernetes.io/pod/allow-read-only-root-filesystem-false](#rootfs_label)
 - [container.audit.kubernetes.io/\<container-name\>/allow-read-only-root-filesystem-false](#rootfs_label)
-- [audit.kubernetes.io/<namespace-name>/allow-non-default-deny-egress-network-policy](#egress_label)
-- [audit.kubernetes.io/<namespace-name>/allow-non-default-deny-ingress-network-policy](#ingress_label)
+- [audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-egress-network-policy](#egress_label)
+- [audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-ingress-network-policy](#ingress_label)
 
 <a name="allowpe_label"/>
 

--- a/README.md
+++ b/README.md
@@ -415,7 +415,17 @@ spec:
         audit.kubernetes.io/pod/allow-run-as-root: "YourReasonForOverrideHere"
 ```
 
-`kubeaudit` supports many labels on pod or container level:
+`kubeaudit` can also skip a specific audit for all network policies associated with a namespace resource
+by adding a namespace override label. For example if you use `kubeaudit` to ignore `allow-non-default-deny-egress-network-policy` check for a namespace named `namespaceName1` you can add the following label to the namespace:
+
+```sh
+metadata:
+  name: namespaceName1
+  labels:
+    audit.kubernetes.io/namespaceName1/allow-non-default-deny-egress-network-policy: "YourReasonForOverrideHere"
+```
+
+`kubeaudit` supports many labels on pod, namespace or container level:
 - [audit.kubernetes.io/pod/allow-privilege-escalation](#allowpe_label)
 - [container.audit.kubernetes.io/\<container-name\>/allow-privilege-escalation](#allowpe_label)
 - [audit.kubernetes.io/pod/allow-privileged](#priv_label)
@@ -427,6 +437,8 @@ spec:
 - [audit.kubernetes.io/pod/allow-automount-service-account-token](#sat_label)
 - [audit.kubernetes.io/pod/allow-read-only-root-filesystem-false](#rootfs_label)
 - [container.audit.kubernetes.io/\<container-name\>/allow-read-only-root-filesystem-false](#rootfs_label)
+- [audit.kubernetes.io/<namespace-name>/allow-non-default-deny-egress-network-policy](#egress_label)
+- [audit.kubernetes.io/<namespace-name>/allow-non-default-deny-ingress-network-policy](#ingress_label)
 
 <a name="allowpe_label"/>
 
@@ -518,6 +530,24 @@ Allows setting `readOnlyRootFilesystem` to `false` to all containers in a pod.
 kubeaudit.allow.readOnlyRootFilesystemFalse: "Write permissions needed"
 
 WARN[0000] Allowed setting readOnlyRootFilesystem to false Reason="Write permissions needed"
+```
+
+<a name="egress_label"/>
+
+### audit.kubernetes.io/<namespace-name>/allow-non-default-deny-egress-network-policy
+
+Allows absense of `default-deny` egress network policy for that specific namespace.
+
+<a name="ingress_label"/>
+
+### audit.kubernetes.io/<namespace-name>/allow-non-default-deny-ingress-network-policy
+
+Allows absense of `default-deny` ingress network policy for that specific namespace.
+
+```sh
+audit.kubernetes.io/default/allow-non-default-deny-egress-network-policy: "Egress is allowed"
+
+WARN[0000] Allowed Namespace without a default deny ingress NetworkPolicy  KubeType=namespace Name=default Reason="Egress is allowed"
 ```
 
 <a name="contribute" />

--- a/README.md
+++ b/README.md
@@ -534,13 +534,13 @@ WARN[0000] Allowed setting readOnlyRootFilesystem to false Reason="Write permiss
 
 <a name="egress_label"/>
 
-### audit.kubernetes.io/<namespace-name>/allow-non-default-deny-egress-network-policy
+### audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-egress-network-policy
 
 Allows absense of `default-deny` egress network policy for that specific namespace.
 
 <a name="ingress_label"/>
 
-### audit.kubernetes.io/<namespace-name>/allow-non-default-deny-ingress-network-policy
+### audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-ingress-network-policy
 
 Allows absense of `default-deny` ingress network policy for that specific namespace.
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -83,12 +83,18 @@ const (
 	ErrorSeccompDeprecated
 	// InfoImageCorrect occurs when an image tag is correct.
 	InfoImageCorrect
-	// ErrorMissingDefaultDenyIngressAndEgressNetworkPolicy missing a default deny egress and default deny egress NetworkPolicy
+	// ErrorMissingDefaultDenyIngressAndEgressNetworkPolicy missing a default deny egress and default deny egress NetworkPolicy but it's set to be allowed
 	ErrorMissingDefaultDenyIngressAndEgressNetworkPolicy
+	// ErrorMissingDefaultDenyIngressAndEgressNetworkPolicyAllowed occurs when missing a default deny egress and default deny egress NetworkPolicy but it's set to be allowed
+	ErrorMissingDefaultDenyIngressAndEgressNetworkPolicyAllowed
 	// ErrorMissingDefaultDenyEgressNetworkPolicy occurs when a namespace is missing a default deny egress NetworkPolicy
 	ErrorMissingDefaultDenyEgressNetworkPolicy
+	// ErrorMissingDefaultDenyEgressNetworkPolicyAllowed occurs when a namespace is missing a default deny egress NetworkPolicy but it's allowed
+	ErrorMissingDefaultDenyEgressNetworkPolicyAllowed
 	// ErrorMissingDefaultDenyEgressNetworkPolicy occurs when a namespace is missing a default deny ingress NetworkPolicy
 	ErrorMissingDefaultDenyIngressNetworkPolicy
+	// ErrorMissingDefaultDenyIngressNetworkPolicyAllowed  occurs when a namespace is missing a default deny ingress NetworkPolicy but it's allowed
+	ErrorMissingDefaultDenyIngressNetworkPolicyAllowed
 	// InfoDefaultDenyNetworkPolicyExists occurs when a namespace has a default deny NetworkPolicy
 	InfoDefaultDenyNetworkPolicyExists
 	// WarningAllowAllIngressNetworkPolicyExists occurs when a namespace has an allow all ingress NetworkPolicy

--- a/cmd/networkPolicies.go
+++ b/cmd/networkPolicies.go
@@ -105,7 +105,7 @@ func checkNamespaceNetworkPolicies(netPols *NetworkPolicyListV1, result *Result,
 				container: "",
 				id:        ErrorMissingDefaultDenyIngressAndEgressNetworkPolicyAllowed,
 				kind:      Warn,
-				message:   "Allowed Namespace is missing a default deny ingress and default deny egress NetworkPolicy",
+				message:   "Allowed Namespace without a default deny ingress and default deny egress NetworkPolicy",
 				metadata:  Metadata{"Reason": prettifyReason("Ingress: " + ingressReason + " Egress: " + egressReason)},
 			}
 			result.Occurrences = append(result.Occurrences, occ)
@@ -128,7 +128,7 @@ func checkNamespaceNetworkPolicies(netPols *NetworkPolicyListV1, result *Result,
 				container: "",
 				id:        ErrorMissingDefaultDenyIngressNetworkPolicyAllowed,
 				kind:      Warn,
-				message:   "Allowed Namespace is missing a default deny ingress NetworkPolicy",
+				message:   "Allowed Namespace without a default deny ingress NetworkPolicy",
 				metadata:  Metadata{"Reason": prettifyReason(ingressReason)},
 			}
 			result.Occurrences = append(result.Occurrences, occ)
@@ -151,7 +151,7 @@ func checkNamespaceNetworkPolicies(netPols *NetworkPolicyListV1, result *Result,
 				container: "",
 				id:        ErrorMissingDefaultDenyEgressNetworkPolicyAllowed,
 				kind:      Warn,
-				message:   "Allowed Namespace is missing a default deny ingress NetworkPolicy",
+				message:   "Allowed Namespace without a default deny ingress NetworkPolicy",
 				metadata:  Metadata{"Reason": prettifyReason(egressReason)},
 			}
 			result.Occurrences = append(result.Occurrences, occ)
@@ -177,7 +177,6 @@ func checkNamespaceNetworkPolicies(netPols *NetworkPolicyListV1, result *Result,
 		}
 		result.Occurrences = append(result.Occurrences, occ)
 	}
-
 	return
 }
 

--- a/cmd/networkPolicies_test.go
+++ b/cmd/networkPolicies_test.go
@@ -21,3 +21,15 @@ func TestNamespaceHasDefaulDenyNetPol(t *testing.T) {
 func TestNamespaceHasDefaulDenyAndAllowAllNetPol(t *testing.T) {
 	runAuditTest(t, "namespace_has_default_deny_and_allow_all_netpol.yml", auditNetworkPolicies, []int{InfoDefaultDenyNetworkPolicyExists, WarningAllowAllIngressNetworkPolicyExists, WarningAllowAllEgressNetworkPolicyExists})
 }
+
+func TestAllowedNamespaceMissingDefaulDenyNetPol(t *testing.T) {
+	runAuditTest(t, "allowed_namespace_missing_default_deny_netpol.yml", auditNetworkPolicies, []int{ErrorMissingDefaultDenyIngressAndEgressNetworkPolicyAllowed})
+}
+
+func TestAllowedNamespaceMissingDefaultDenyEgressNetPol(t *testing.T) {
+	runAuditTest(t, "allowed_namespace_missing_default_deny_egress_netpol.yml", auditNetworkPolicies, []int{ErrorMissingDefaultDenyEgressNetworkPolicyAllowed})
+}
+
+func TestAllowedNamespaceMissingDefaultDenyIngressNetPol(t *testing.T) {
+	runAuditTest(t, "allowed_namespace_missing_default_deny_ingress_netpol.yml", auditNetworkPolicies, []int{ErrorMissingDefaultDenyIngressNetworkPolicyAllowed})
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -387,6 +387,20 @@ func getPodOverrideLabelReason(result *Result, overrideLabel string) (bool, stri
 	return false, ""
 }
 
+func getNamespaceOverrideLabelReason(result *Result, nsName string, policyType string) (bool, string) {
+	var namespaceOverrideLabel string
+	if policyType == "egress" {
+		namespaceOverrideLabel = "audit.kubernetes.io/" + nsName + "/" + "allow-non-default-deny-egress-network-policy"
+	}
+	if policyType == "ingress" {
+		namespaceOverrideLabel = "audit.kubernetes.io/" + nsName + "/" + "allow-non-default-deny-ingress-network-policy"
+	}
+	if reason := result.Labels[namespaceOverrideLabel]; reason != "" {
+		return true, reason
+	}
+	return false, ""
+}
+
 func isDefinedCapOverrideLabel(result *Result, container ContainerV1, capName string) bool {
 	capNameKey := strings.Replace(capName, "_", "-", -1)
 	containerKeyString := "container.audit.kubernetes.io/" + container.Name + "/allow-capability-" + capNameKey

--- a/fixtures/allowed_namespace_missing_default_deny_egress_netpol.yml
+++ b/fixtures/allowed_namespace_missing_default_deny_egress_netpol.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "default"
+  labels:
+    audit.kubernetes.io/default/allow-non-default-deny-egress-network-policy: "Egress is allowed"
+---
+# https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/fixtures/allowed_namespace_missing_default_deny_ingress_netpol.yml
+++ b/fixtures/allowed_namespace_missing_default_deny_ingress_netpol.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "default"
+  labels:
+    audit.kubernetes.io/default/allow-non-default-deny-ingress-network-policy: "Ingress is allowed"
+---
+# https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress

--- a/fixtures/allowed_namespace_missing_default_deny_netpol.yml
+++ b/fixtures/allowed_namespace_missing_default_deny_netpol.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "default"
+  labels:
+    audit.kubernetes.io/default/allow-non-default-deny-egress-network-policy: "Just for fun"
+    audit.kubernetes.io/default/allow-non-default-deny-ingress-network-policy: "Just for fun as well"
+---
+# https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/07-allow-traffic-from-some-pods-in-another-namespace.md
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: web-allow-all-ns-monitoring
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: web
+  ingress:
+    - from:
+      - namespaceSelector:     # chooses all pods in namespaces labelled with team=operations
+          matchLabels:
+            team: operations
+        podSelector:           # chooses pods with type=monitoring
+          matchLabels:
+            type: monitoring


### PR DESCRIPTION

##### Description
This PR adds support for Network Policy auditing overrides. 

Fixes # (issue)
closes #160 
##### Type of change

- [x] New feature :sparkles:
- [x] This change requires a documentation update :book:

##### How Has This Been Tested?

- [x]  TestAllowedNamespaceMissingDefaulDenyNetPol
- [x] TestAllowedNamespaceMissingDefaultDenyEgressNetPol
- [x] TestAllowedNamespaceMissingDefaultDenyIngressNetPol

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
