### PR TITLE
[FEATURE] Audit Pod Namespace Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ The manifest might end up a little too secure for the work it is supposed to do.
 - [Audit Service Accounts](#sat)
 - [Audit network policies](#netpol)
 - [Audit resources](#resources)
+- [Audit AppArmour](#apparmour)
+- [Audit Seccomp](#seccomp)
+- [Audit namespaces](#namespaces)
 
 <a name="all" />
 
@@ -314,6 +317,8 @@ WARN[0000] CPU limit exceeded, it is set to 1 but it must not exceed 500m. Pleas
 WARN[0000] Memory limit exceeded, it is set to 512Mi but it must not exceed 125Mi. Please adjust it!
 ```
 
+<a name="apparmour" />
+
 ## Audit AppArmor
 
 It checks that AppArmor is enabled for all containers by making sure the following annotation exists on the pod.
@@ -339,6 +344,8 @@ kubeaudit apparmor
 ERRO[0000] AppArmor disabled. Annotation=container.apparmor.security.beta.kubernetes.io/myContainer
   Container=myContainer KubeType=pod Name=myPod Namespace=myNamespace Reason=badval
 ```
+
+<a name="seccomp" />
 
 ## Audit Seccomp
 
@@ -377,6 +384,19 @@ When Seccomp annotations are misconfigured for a pod:
 kubeaudit seccomp
 ERRO[0000] Seccomp disabled for pod. Annotation=seccomp.security.alpha.kubernetes.io/pod Container= KubeType=pod
   Name=myPod Namespace=myNamespace Reason=unconfined
+```
+
+<a name="seccomp" />
+
+## Audit namespaces
+
+`kubeaudit` will detect whether `hostNetwork`,`hostIPC` or `hostPID` is either set to `true` in `podSpec` for `Pod` workloads 
+
+```sh
+kubeaudit namespaces
+ERRO[0000] hostNetwork is set to true  in podSpec, please set to false!
+ERRO[0000] hostIPC is set to true  in podSpec, please set to false!
+ERRO[0000] hostPID is set to true  in podSpec, please set to false!
 ```
 
 <a name="labels" />
@@ -444,6 +464,9 @@ metadata:
 - [container.audit.kubernetes.io/\<container-name\>/allow-read-only-root-filesystem-false](#rootfs_label)
 - [audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-egress-network-policy](#egress_label)
 - [audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-ingress-network-policy](#ingress_label)
+- [audit.kubernetes.io/pod/allow-namespace-host-network](#namespacenetwork_label)
+- [audit.kubernetes.io/pod/allow-namespace-host-IPC](#namespaceipc_label)
+- [audit.kubernetes.io/pod/allow-namespace-host-PID](#namespacepid_label)
 
 <a name="allowpe_label"/>
 
@@ -555,6 +578,36 @@ audit.kubernetes.io/default/allow-non-default-deny-egress-network-policy: "Egres
 WARN[0000] Allowed Namespace without a default deny egress NetworkPolicy  KubeType=namespace Name=default Reason="Egress is allowed"
 ```
 
+<a name="#namespacenetwork_label"/>
+
+### audit.kubernetes.io/pod/allow-namespace-host-network
+
+```sh
+audit.kubernetes.io/pod/allow-namespace-host-network: "hostNetwork is allowed"
+
+WARN[0000] Allowed setting hostNetwork to true           KubeType=pod Name=Pod Namespace=PodNamespace Reason="hostNetwork is allowed"
+```
+
+<a name="#namespaceipc_label"/>
+
+### audit.kubernetes.io/pod/allow-namespace-host-IPC
+
+```sh
+audit.kubernetes.io/pod/allow-namespace-host-IPC: "hostIPC is allowed"
+
+WARN[0000] Allowed setting hostIPC to true               KubeType=pod Name=Pod Namespace=PodNamespace Reason="hostIPC is allowed"
+```
+
+<a name="#namespacepid_label"/>
+
+### audit.kubernetes.io/pod/allow-namespace-host-PID
+
+```sh
+audit.kubernetes.io/pod/allow-namespace-host-PID: "hostPID is allowed"
+
+WARN[0000] Allowed setting hostPID to true               KubeType=pod Name=Pod Namespace=PodNamespace Reason="hostPID is allowed"
+```
+
 <a name="contribute" />
 
 ## Drop capabilities list
@@ -617,7 +670,10 @@ spec:
     automount-service-account-token: deny           # Set to `allow` to skip auditing potential vulnerability
     read-only-root-filesystem-false: deny           # Set to `allow` to skip auditing potential vulnerability
     non-default-deny-ingress-network-policy: deny   # Set to `allow` to skip auditing potential vulnerability
-    non-default-deny-egress-network-policy: deny   # Set to `allow` to skip auditing potential vulnerability
+    non-default-deny-egress-network-policy: deny    # Set to `allow` to skip auditing potential vulnerability
+    namespace-host-network: deny                    # Set to `allow` to skip auditing potential vulnerability
+    namespace-host-IPC: deny                        # Set to `allow` to skip auditing potential vulnerability
+    namespace-host-PID: deny                        # Set to `allow` to skip auditing potential vulnerability
 ```
 
 <a name="contribute" />

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The manifest might end up a little too secure for the work it is supposed to do.
 - [Audit Service Accounts](#sat)
 - [Audit network policies](#netpol)
 - [Audit resources](#resources)
-- [Audit AppArmour](#apparmour)
+- [Audit AppArmor](#apparmor)
 - [Audit Seccomp](#seccomp)
 - [Audit namespaces](#namespaces)
 
@@ -317,7 +317,7 @@ WARN[0000] CPU limit exceeded, it is set to 1 but it must not exceed 500m. Pleas
 WARN[0000] Memory limit exceeded, it is set to 512Mi but it must not exceed 125Mi. Please adjust it!
 ```
 
-<a name="apparmour" />
+<a name="apparmor" />
 
 ## Audit AppArmor
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ ERRO[0000] Seccomp disabled for pod. Annotation=seccomp.security.alpha.kubernete
   Name=myPod Namespace=myNamespace Reason=unconfined
 ```
 
-<a name="seccomp" />
+<a name="namespaces" />
 
 ## Audit namespaces
 
@@ -578,7 +578,7 @@ audit.kubernetes.io/default/allow-non-default-deny-egress-network-policy: "Egres
 WARN[0000] Allowed Namespace without a default deny egress NetworkPolicy  KubeType=namespace Name=default Reason="Egress is allowed"
 ```
 
-<a name="#namespacenetwork_label"/>
+<a name="namespacenetwork_label"/>
 
 ### audit.kubernetes.io/pod/allow-namespace-host-network
 
@@ -588,7 +588,7 @@ audit.kubernetes.io/pod/allow-namespace-host-network: "hostNetwork is allowed"
 WARN[0000] Allowed setting hostNetwork to true           KubeType=pod Name=Pod Namespace=PodNamespace Reason="hostNetwork is allowed"
 ```
 
-<a name="#namespaceipc_label"/>
+<a name="namespaceipc_label"/>
 
 ### audit.kubernetes.io/pod/allow-namespace-host-IPC
 
@@ -598,7 +598,7 @@ audit.kubernetes.io/pod/allow-namespace-host-IPC: "hostIPC is allowed"
 WARN[0000] Allowed setting hostIPC to true               KubeType=pod Name=Pod Namespace=PodNamespace Reason="hostIPC is allowed"
 ```
 
-<a name="#namespacepid_label"/>
+<a name="namespacepid_label"/>
 
 ### audit.kubernetes.io/pod/allow-namespace-host-PID
 

--- a/cmd/all.go
+++ b/cmd/all.go
@@ -7,7 +7,7 @@ import (
 var allAuditFunctions = []interface{}{
 	auditAllowPrivilegeEscalation, auditReadOnlyRootFS, auditRunAsNonRoot,
 	auditAutomountServiceAccountToken, auditPrivileged, auditCapabilities,
-	auditLimits, auditImages, auditAppArmor, auditSeccomp, auditNetworkPolicies,
+	auditLimits, auditImages, auditAppArmor, auditSeccomp, auditNetworkPolicies, auditNamespaces,
 }
 
 var auditAllCmd = &cobra.Command{

--- a/cmd/autofix_util.go
+++ b/cmd/autofix_util.go
@@ -48,6 +48,8 @@ func fixPotentialSecurityIssue(resource Resource, result Result) Resource {
 			resource = fixSeccomp(resource)
 		case ErrorMissingDefaultDenyIngressNetworkPolicy, ErrorMissingDefaultDenyEgressNetworkPolicy, ErrorMissingDefaultDenyIngressAndEgressNetworkPolicy:
 			resource = fixNetworkPolicy(resource, occurrence)
+		case ErrorNamespaceHostIPCTrue, ErrorNamespaceHostNetworkTrue, ErrorNamespaceHostPIDTrue:
+			resource = fixNamespace(&result, resource)
 		}
 	}
 	return resource

--- a/cmd/autofix_util.go
+++ b/cmd/autofix_util.go
@@ -16,7 +16,7 @@ func getAuditFunctions() []interface{} {
 	return []interface{}{
 		auditAllowPrivilegeEscalation, auditReadOnlyRootFS, auditRunAsNonRoot,
 		auditAutomountServiceAccountToken, auditPrivileged, auditCapabilities,
-		auditAppArmor, auditSeccomp, auditNetworkPolicies,
+		auditAppArmor, auditSeccomp, auditNetworkPolicies, auditNamespaces,
 	}
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -48,6 +48,9 @@ type KubeauditConfigOverrides struct {
 	ReadOnlyRootFilesystemFalse        string `yaml:"read-only-root-filesystem-false"`
 	NonDefaultDenyIngressNetworkPolicy string `yaml:"non-default-deny-ingress-network-policy"`
 	NonDefaultDenyEgressNetworkPolicy  string `yaml:"non-default-deny-egress-network-policy"`
+	HostNetwork                        string `yaml:"namespace-host-network"`
+	HostPID                            string `yaml:"namespace-host-PID"`
+	HostIPC                            string `yaml:"namespace-host-IPC"`
 }
 
 func mapOverridesToStructFields(label string) string {
@@ -71,6 +74,15 @@ func mapOverridesToStructFields(label string) string {
 	}
 	if label == "allow-non-default-deny-ingress-network-policy" {
 		return "NonDefaultDenyIngressNetworkPolicy"
+	}
+	if label == "allow-namespace-host-network" {
+		return "HostNetwork"
+	}
+	if label == "allow-namespace-host-IPC" {
+		return "HostIPC"
+	}
+	if label == "allow-namespace-host-PID" {
+		return "HostPID"
 	}
 	return ""
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -54,34 +54,26 @@ type KubeauditConfigOverrides struct {
 }
 
 func mapOverridesToStructFields(label string) string {
-	if label == "allow-privilege-escalation" {
+	switch label {
+	case "allow-privilege-escalation":
 		return "PrivilegeEscalation"
-	}
-	if label == "allow-privileged" {
+	case "allow-privileged":
 		return "Privileged"
-	}
-	if label == "allow-run-as-root" {
+	case "allow-run-as-root":
 		return "RunAsRoot"
-	}
-	if label == "allow-automount-service-account-token" {
+	case "allow-automount-service-account-token":
 		return "AutomountServiceAccountToken"
-	}
-	if label == "allow-read-only-root-filesystem-false" {
+	case "allow-read-only-root-filesystem-false":
 		return "ReadOnlyRootFilesystemFalse"
-	}
-	if label == "allow-non-default-deny-egress-network-policy" {
+	case "allow-non-default-deny-egress-network-policy":
 		return "NonDefaultDenyEgressNetworkPolicy"
-	}
-	if label == "allow-non-default-deny-ingress-network-policy" {
+	case "allow-non-default-deny-ingress-network-policy":
 		return "NonDefaultDenyIngressNetworkPolicy"
-	}
-	if label == "allow-namespace-host-network" {
+	case "allow-namespace-host-network":
 		return "HostNetwork"
-	}
-	if label == "allow-namespace-host-IPC" {
+	case "allow-namespace-host-IPC":
 		return "HostIPC"
-	}
-	if label == "allow-namespace-host-PID" {
+	case "allow-namespace-host-PID":
 		return "HostPID"
 	}
 	return ""

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -95,6 +95,18 @@ const (
 	ErrorMissingDefaultDenyIngressNetworkPolicy
 	// ErrorMissingDefaultDenyIngressNetworkPolicyAllowed  occurs when a namespace is missing a default deny ingress NetworkPolicy but it's allowed
 	ErrorMissingDefaultDenyIngressNetworkPolicyAllowed
+	//  ErrorNamespaceHostIPCTrue occurs when a hostIPC is set to true in PodSpec
+	ErrorNamespaceHostIPCTrue
+	//  ErrorNamespaceHostIPCTrueAllowed occurs when a hostIPC is set to true in PodSpec but it's allowed
+	ErrorNamespaceHostIPCAllowed
+	//  ErrorNamespaceHostIPCTrue occurs when a hostNetwork is set to true in PodSpec
+	ErrorNamespaceHostNetworkTrue
+	//  ErrorNamespaceHostIPCTrueAllowed occurs when a hostNetwork is set to true in PodSpec but it's allowed
+	ErrorNamespaceHostNetworkAllowed
+	//  ErrorNamespaceHostIPCTrue occurs when a hostPID is set to true in PodSpec
+	ErrorNamespaceHostPIDTrue
+	//  ErrorNamespaceHostIPCTrue occurs when a hostPID is set to true in PodSpec but it's allowed
+	ErrorNamespaceHostPIDAllowed
 	// InfoDefaultDenyNetworkPolicyExists occurs when a namespace has a default deny NetworkPolicy
 	InfoDefaultDenyNetworkPolicyExists
 	// WarningAllowAllIngressNetworkPolicyExists occurs when a namespace has an allow all ingress NetworkPolicy

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -98,15 +98,15 @@ const (
 	//  ErrorNamespaceHostIPCTrue occurs when a hostIPC is set to true in PodSpec
 	ErrorNamespaceHostIPCTrue
 	//  ErrorNamespaceHostIPCTrueAllowed occurs when a hostIPC is set to true in PodSpec but it's allowed
-	ErrorNamespaceHostIPCAllowed
+	ErrorNamespaceHostIPCTrueAllowed
 	//  ErrorNamespaceHostIPCTrue occurs when a hostNetwork is set to true in PodSpec
 	ErrorNamespaceHostNetworkTrue
-	//  ErrorNamespaceHostIPCTrueAllowed occurs when a hostNetwork is set to true in PodSpec but it's allowed
-	ErrorNamespaceHostNetworkAllowed
+	//  ErrorNamespaceHostNetworkTrueAllowed occurs when a hostNetwork is set to true in PodSpec but it's allowed
+	ErrorNamespaceHostNetworkTrueAllowed
 	//  ErrorNamespaceHostIPCTrue occurs when a hostPID is set to true in PodSpec
 	ErrorNamespaceHostPIDTrue
-	//  ErrorNamespaceHostIPCTrue occurs when a hostPID is set to true in PodSpec but it's allowed
-	ErrorNamespaceHostPIDAllowed
+	//  ErrorNamespaceHostPIDTrueAllowed occurs when a hostPID is set to true in PodSpec but it's allowed
+	ErrorNamespaceHostPIDTrueAllowed
 	// InfoDefaultDenyNetworkPolicyExists occurs when a namespace has a default deny NetworkPolicy
 	InfoDefaultDenyNetworkPolicyExists
 	// WarningAllowAllIngressNetworkPolicyExists occurs when a namespace has an allow all ingress NetworkPolicy

--- a/cmd/namespaces.go
+++ b/cmd/namespaces.go
@@ -89,7 +89,7 @@ func checkNamespaces(podSpec PodSpecV1, result *Result) {
 			podHost: podSpec.Hostname,
 			id:      ErrorNamespaceHostPIDTrue,
 			kind:    Error,
-			message: "hostPID is set to true  in podSpec, please set to false!",
+			message: "hostPID is set to true in podSpec, please set to false!",
 		}
 		result.Occurrences = append(result.Occurrences, occ)
 	}

--- a/cmd/namespaces.go
+++ b/cmd/namespaces.go
@@ -11,7 +11,7 @@ func checkNamespaces(podSpec PodSpecV1, result *Result) {
 		if podSpec.HostNetwork {
 			occ := Occurrence{
 				podHost:  podSpec.Hostname,
-				id:       ErrorNamespaceHostNetworkAllowed,
+				id:       ErrorNamespaceHostNetworkTrueAllowed,
 				kind:     Warn,
 				message:  "Allowed setting hostNetwork to true",
 				metadata: Metadata{"Reason": prettifyReason(reason)},
@@ -40,7 +40,7 @@ func checkNamespaces(podSpec PodSpecV1, result *Result) {
 		if podSpec.HostIPC {
 			occ := Occurrence{
 				podHost:  podSpec.Hostname,
-				id:       ErrorNamespaceHostIPCAllowed,
+				id:       ErrorNamespaceHostIPCTrueAllowed,
 				kind:     Warn,
 				message:  "Allowed setting hostIPC to true",
 				metadata: Metadata{"Reason": prettifyReason(reason)},
@@ -69,7 +69,7 @@ func checkNamespaces(podSpec PodSpecV1, result *Result) {
 		if podSpec.HostPID {
 			occ := Occurrence{
 				podHost:  podSpec.Hostname,
-				id:       ErrorNamespaceHostPIDAllowed,
+				id:       ErrorNamespaceHostPIDTrueAllowed,
 				kind:     Warn,
 				message:  "Allowed setting hostPID to true",
 				metadata: Metadata{"Reason": prettifyReason(reason)},
@@ -123,13 +123,12 @@ var namespacesCmd = &cobra.Command{
 	Use:   "namespaces",
 	Short: "Audit Pods for hostNetwork, hostIPC and hostPID",
 	Long: `This command determines which pods in a kubernetes cluster
-are running as root (uid=0).
+are running with hostNetwork, hostIPC or hostPID set to true.
+	
+A PASS is given when a pod has hostNetwork, hostIPC and hostPID set to false or not set
+A FAIL is generated when a pod has at least one of hostNetwork, hostIPC or hostPID set to true
 
-A PASS is given when a container runs as a uid greater than 0
-A FAIL is generated when a container runs as root
-
-Example usage:
-kubeaudit nonroot`,
+kubeaudit namespaces`,
 	Run: runAudit(auditNamespaces),
 }
 

--- a/cmd/namespaces.go
+++ b/cmd/namespaces.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// Checks the PodSecurityContext for NIX
+func checkNamespaces(podSpec PodSpecV1, result *Result) {
+	if labelExists, reason := getPodOverrideLabelReason(result, "allow-namespace-host-network"); labelExists {
+		if podSpec.HostNetwork {
+			occ := Occurrence{
+				podHost:  podSpec.Hostname,
+				id:       ErrorNamespaceHostNetworkAllowed,
+				kind:     Warn,
+				message:  "Allowed setting hostNetwork to true",
+				metadata: Metadata{"Reason": prettifyReason(reason)},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		} else {
+			occ := Occurrence{
+				podHost:  podSpec.Hostname,
+				id:       ErrorMisconfiguredKubeauditAllow,
+				kind:     Warn,
+				message:  "Allowed setting hostNetwork to true, but it is set to false",
+				metadata: Metadata{"Reason": prettifyReason(reason)},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		}
+	} else if podSpec.HostNetwork {
+		occ := Occurrence{
+			podHost: podSpec.Hostname,
+			id:      ErrorNamespaceHostNetworkTrue,
+			kind:    Error,
+			message: "hostNetwork is set to true  in podSpec, please set to false!",
+		}
+		result.Occurrences = append(result.Occurrences, occ)
+	}
+	if labelExists, reason := getPodOverrideLabelReason(result, "allow-namespace-host-IPC"); labelExists {
+		if podSpec.HostIPC {
+			occ := Occurrence{
+				podHost:  podSpec.Hostname,
+				id:       ErrorNamespaceHostIPCAllowed,
+				kind:     Warn,
+				message:  "Allowed setting hostIPC to true",
+				metadata: Metadata{"Reason": prettifyReason(reason)},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		} else {
+			occ := Occurrence{
+				podHost:  podSpec.Hostname,
+				id:       ErrorMisconfiguredKubeauditAllow,
+				kind:     Warn,
+				message:  "Allowed setting hostIPC to true, but it is set to false",
+				metadata: Metadata{"Reason": prettifyReason(reason)},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		}
+	} else if podSpec.HostIPC {
+		occ := Occurrence{
+			podHost: podSpec.Hostname,
+			id:      ErrorNamespaceHostIPCTrue,
+			kind:    Error,
+			message: "hostIPC is set to true  in podSpec, please set to false!",
+		}
+		result.Occurrences = append(result.Occurrences, occ)
+	}
+	if labelExists, reason := getPodOverrideLabelReason(result, "allow-namespace-host-PID"); labelExists {
+		if podSpec.HostPID {
+			occ := Occurrence{
+				podHost:  podSpec.Hostname,
+				id:       ErrorNamespaceHostPIDAllowed,
+				kind:     Warn,
+				message:  "Allowed setting hostPID to true",
+				metadata: Metadata{"Reason": prettifyReason(reason)},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		} else {
+			occ := Occurrence{
+				podHost:  podSpec.Hostname,
+				id:       ErrorMisconfiguredKubeauditAllow,
+				kind:     Warn,
+				message:  "Allowed setting hostPID to true, but it is set to false",
+				metadata: Metadata{"Reason": prettifyReason(reason)},
+			}
+			result.Occurrences = append(result.Occurrences, occ)
+		}
+	} else if podSpec.HostPID {
+		occ := Occurrence{
+			podHost: podSpec.Hostname,
+			id:      ErrorNamespaceHostPIDTrue,
+			kind:    Error,
+			message: "hostPID is set to true  in podSpec, please set to false!",
+		}
+		result.Occurrences = append(result.Occurrences, occ)
+	}
+	return
+}
+
+func auditNamespaces(resource Resource) (results []Result) {
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		podSpec := kubeType.Spec
+		result, err, warn := newResultFromResource(resource)
+		if warn != nil {
+			log.Warn(warn)
+			return
+		}
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		checkNamespaces(podSpec, result)
+		if len(result.Occurrences) > 0 {
+			results = append(results, *result)
+		}
+	}
+	return
+}
+
+// runAsNonRootCmd represents the runAsNonRoot command
+var namespacesCmd = &cobra.Command{
+	Use:   "namespaces",
+	Short: "Audit Pods for hostNetwork, hostIPC and hostPID",
+	Long: `This command determines which pods in a kubernetes cluster
+are running as root (uid=0).
+
+A PASS is given when a container runs as a uid greater than 0
+A FAIL is generated when a container runs as root
+
+Example usage:
+kubeaudit nonroot`,
+	Run: runAudit(auditNamespaces),
+}
+
+func init() {
+	RootCmd.AddCommand(namespacesCmd)
+}

--- a/cmd/namespaces.go
+++ b/cmd/namespaces.go
@@ -60,7 +60,7 @@ func checkNamespaces(podSpec PodSpecV1, result *Result) {
 			podHost: podSpec.Hostname,
 			id:      ErrorNamespaceHostIPCTrue,
 			kind:    Error,
-			message: "hostIPC is set to true  in podSpec, please set to false!",
+			message: "hostIPC is set to true in podSpec, please set to false!",
 		}
 		result.Occurrences = append(result.Occurrences, occ)
 	}

--- a/cmd/namespaces.go
+++ b/cmd/namespaces.go
@@ -31,7 +31,7 @@ func checkNamespaces(podSpec PodSpecV1, result *Result) {
 			podHost: podSpec.Hostname,
 			id:      ErrorNamespaceHostNetworkTrue,
 			kind:    Error,
-			message: "hostNetwork is set to true  in podSpec, please set to false!",
+			message: "hostNetwork is set to true in podSpec, please set to false!",
 		}
 		result.Occurrences = append(result.Occurrences, occ)
 	}

--- a/cmd/namespaces.go
+++ b/cmd/namespaces.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -101,15 +100,7 @@ func auditNamespaces(resource Resource) (results []Result) {
 	switch kubeType := resource.(type) {
 	case *PodV1:
 		podSpec := kubeType.Spec
-		result, err, warn := newResultFromResource(resource)
-		if warn != nil {
-			log.Warn(warn)
-			return
-		}
-		if err != nil {
-			log.Error(err)
-			return
-		}
+		result, _, _ := newResultFromResource(resource)
 		checkNamespaces(podSpec, result)
 		if len(result.Occurrences) > 0 {
 			results = append(results, *result)

--- a/cmd/namespaces_fixes.go
+++ b/cmd/namespaces_fixes.go
@@ -1,0 +1,20 @@
+package cmd
+
+func fixNamespace(result *Result, resource Resource) Resource {
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		if labelExists, _ := getPodOverrideLabelReason(result, "allow-namespace-host-network"); !labelExists {
+			kubeType.Spec.HostNetwork = false
+			resource = kubeType.DeepCopyObject()
+		}
+		if labelExists, _ := getPodOverrideLabelReason(result, "allow-namespace-host-PID"); !labelExists {
+			kubeType.Spec.HostPID = false
+			resource = kubeType.DeepCopyObject()
+		}
+		if labelExists, _ := getPodOverrideLabelReason(result, "allow-namespace-host-IPC"); !labelExists {
+			kubeType.Spec.HostIPC = false
+			resource = kubeType.DeepCopyObject()
+		}
+	}
+	return resource
+}

--- a/cmd/namespaces_fixes.go
+++ b/cmd/namespaces_fixes.go
@@ -5,16 +5,14 @@ func fixNamespace(result *Result, resource Resource) Resource {
 	case *PodV1:
 		if labelExists, _ := getPodOverrideLabelReason(result, "allow-namespace-host-network"); !labelExists {
 			kubeType.Spec.HostNetwork = false
-			resource = kubeType.DeepCopyObject()
 		}
 		if labelExists, _ := getPodOverrideLabelReason(result, "allow-namespace-host-PID"); !labelExists {
 			kubeType.Spec.HostPID = false
-			resource = kubeType.DeepCopyObject()
 		}
 		if labelExists, _ := getPodOverrideLabelReason(result, "allow-namespace-host-IPC"); !labelExists {
 			kubeType.Spec.HostIPC = false
-			resource = kubeType.DeepCopyObject()
 		}
+		return kubeType.DeepCopyObject()
 	}
 	return resource
 }

--- a/cmd/namespaces_fixes_test.go
+++ b/cmd/namespaces_fixes_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestFixHostNetworkTrueV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "host_network_true_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.False(kubeType.Spec.HostNetwork)
+	}
+}
+func TestFixHostIPCTrueV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "host_IPC_true_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.False(kubeType.Spec.HostNetwork)
+	}
+}
+func TestFixHostPIDTrueV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "host_PID_true_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.False(kubeType.Spec.HostNetwork)
+	}
+}
+
+func TestFixHostNetworkTrueAllowedV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "host_network_true_allowed_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.True(kubeType.Spec.HostNetwork)
+	}
+}
+func TestFixHostIPCTrueAllowedV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "host_IPC_true_allowed_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.True(kubeType.Spec.HostIPC)
+	}
+}
+func TestFixHostPIDTrueAllowedV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "host_PID_true_allowed_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.True(kubeType.Spec.HostPID)
+	}
+}
+
+func TestFixNamespacesMisconfiguredAllowV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "namespaces_misconfigured_allow_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.False(kubeType.Spec.HostNetwork)
+	}
+}
+func TestFixNamespacesAllTrueV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "namespaces_all_true_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.False(kubeType.Spec.HostNetwork)
+		assert.False(kubeType.Spec.HostPID)
+		assert.False(kubeType.Spec.HostIPC)
+	}
+}
+func TestFixNamespacesAllTrueAllowedV1(t *testing.T) {
+	assert, resource := FixTestSetup(t, "namespaces_all_true_allowed_v1.yml", auditNamespaces)
+	switch kubeType := resource.(type) {
+	case *PodV1:
+		assert.True(kubeType.Spec.HostNetwork)
+		assert.True(kubeType.Spec.HostPID)
+		assert.True(kubeType.Spec.HostIPC)
+	}
+}

--- a/cmd/namespaces_test.go
+++ b/cmd/namespaces_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import "testing"
+
+func TestHostNetworkTrueV1(t *testing.T) {
+	runAuditTest(t, "host_network_true_v1.yml", auditNamespaces, []int{ErrorNamespaceHostNetworkTrue})
+}
+
+func TestHostIPCTrueV1(t *testing.T) {
+	runAuditTest(t, "host_IPC_true_v1.yml", auditNamespaces, []int{ErrorNamespaceHostIPCTrue})
+}
+
+func TestHostPIDTrueV1(t *testing.T) {
+	runAuditTest(t, "host_PID_true_v1.yml", auditNamespaces, []int{ErrorNamespaceHostPIDTrue})
+}
+func TestHostNetworkTrueAllowedV1(t *testing.T) {
+	runAuditTest(t, "host_network_true_allowed_v1.yml", auditNamespaces, []int{ErrorNamespaceHostNetworkTrueAllowed})
+}
+
+func TestHostIPCTrueAllowedV1(t *testing.T) {
+	runAuditTest(t, "host_IPC_true_allowed_v1.yml", auditNamespaces, []int{ErrorNamespaceHostIPCTrueAllowed})
+}
+
+func TestHostPIDTrueAllowedV1(t *testing.T) {
+	runAuditTest(t, "host_PID_true_allowed_v1.yml", auditNamespaces, []int{ErrorNamespaceHostPIDTrueAllowed})
+}
+func TestNamespacesMisconfiguredAllowV1(t *testing.T) {
+	runAuditTest(t, "namespaces_misconfigured_allow_v1.yml", auditNamespaces, []int{ErrorMisconfiguredKubeauditAllow})
+}
+
+func TestNamespacesAllTrueV1(t *testing.T) {
+	runAuditTest(t, "namespaces_all_true_v1.yml", auditNamespaces, []int{ErrorNamespaceHostPIDTrue, ErrorNamespaceHostIPCTrue, ErrorNamespaceHostNetworkTrue})
+}
+
+func TestNamespacesAllTrueAllowedV1(t *testing.T) {
+	runAuditTest(t, "namespaces_all_true_allowed_v1.yml", auditNamespaces, []int{ErrorNamespaceHostPIDTrueAllowed, ErrorNamespaceHostIPCTrueAllowed, ErrorNamespaceHostNetworkTrueAllowed})
+}
+
+func TestAllowNamespacesFromConfig(t *testing.T) {
+	rootConfig.auditConfig = "../configs/allow_namespaces_from_config.yml"
+	runAuditTest(t, "host_network_true_v1.yml", auditNamespaces, []int{ErrorNamespaceHostNetworkTrueAllowed, ErrorMisconfiguredKubeauditAllow})
+	runAuditTest(t, "host_IPC_true_v1.yml", auditNamespaces, []int{ErrorNamespaceHostIPCTrueAllowed, ErrorMisconfiguredKubeauditAllow})
+	runAuditTest(t, "host_PID_true_v1.yml", auditNamespaces, []int{ErrorNamespaceHostPIDTrueAllowed, ErrorMisconfiguredKubeauditAllow})
+	rootConfig.auditConfig = ""
+}

--- a/configs/allow_namespaces_from_config.yml
+++ b/configs/allow_namespaces_from_config.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: kubeauditConfig
+audit: true
+spec:
+  overrides:
+    namespace-host-network: allow                    # Set to `allow` to skip auditing potential vulnerability
+    namespace-host-IPC: allow                        # Set to `allow` to skip auditing potential vulnerability
+    namespace-host-PID: allow                        # Set to `allow` to skip auditing potential vulnerability

--- a/configs/kubeauditConfig.yaml
+++ b/configs/kubeauditConfig.yaml
@@ -26,5 +26,8 @@ spec:
     run-as-root: deny
     automount-service-account-token: deny
     read-only-root-filesystem-false: deny
-    non-default-deny-egress-network-policy: allow
-    non-default-deny-ingress-network-policy: allow
+    non-default-deny-egress-network-policy: deny
+    non-default-deny-ingress-network-policy: deny
+    namespace-host-network: deny                    
+    namespace-host-IPC: deny                       
+    namespace-host-PID: deny 

--- a/fixtures/host_IPC_true_allowed_v1.yml
+++ b/fixtures/host_IPC_true_allowed_v1.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+    labels:
+        audit.kubernetes.io/pod/allow-namespace-host-IPC: "some reason"
+spec:
+    containers:
+    - name: container
+    hostIPC: true

--- a/fixtures/host_IPC_true_v1.yml
+++ b/fixtures/host_IPC_true_v1.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+spec:
+    containers:
+    - name: container
+    hostIPC: true

--- a/fixtures/host_PID_true_allowed_v1.yml
+++ b/fixtures/host_PID_true_allowed_v1.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+    labels:
+        audit.kubernetes.io/pod/allow-namespace-host-PID: "some reason"
+spec:
+    containers:
+    - name: container
+    hostPID: true

--- a/fixtures/host_PID_true_v1.yml
+++ b/fixtures/host_PID_true_v1.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+spec:
+    containers:
+    - name: container
+    hostPID: true

--- a/fixtures/host_network_true_allowed_v1.yml
+++ b/fixtures/host_network_true_allowed_v1.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+    labels:
+        audit.kubernetes.io/pod/allow-namespace-host-network: "some reason"
+spec:
+    containers:
+    - name: container
+    hostNetwork: true

--- a/fixtures/host_network_true_v1.yml
+++ b/fixtures/host_network_true_v1.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+spec:
+    containers:
+    - name: container
+    hostNetwork: true

--- a/fixtures/namespaces_all_true_allowed_v1.yml
+++ b/fixtures/namespaces_all_true_allowed_v1.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+    labels:
+        audit.kubernetes.io/pod/allow-namespace-host-network: "some reason"
+        audit.kubernetes.io/pod/allow-namespace-host-IPC: "some reason"
+        audit.kubernetes.io/pod/allow-namespace-host-PID: "some reason"
+spec:
+    containers:
+    - name: container
+    hostPID: true
+    hostIPC: true
+    hostNetwork: true

--- a/fixtures/namespaces_all_true_v1.yml
+++ b/fixtures/namespaces_all_true_v1.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+spec:
+    containers:
+    - name: container
+    hostPID: true
+    hostIPC: true
+    hostNetwork: true

--- a/fixtures/namespaces_misconfigured_allow_v1.yml
+++ b/fixtures/namespaces_misconfigured_allow_v1.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: Pod
+    namespace: PodNamespace
+    labels:
+        audit.kubernetes.io/pod/allow-namespace-host-network: "some reason"
+spec:
+    containers:
+    - name: container
+    hostNetwork: false


### PR DESCRIPTION
##### Description

This PR add support for a new type of check- Namespaces(nix)

Following fields are checked for in podSpec:

The use of host's networking | hostNetwork
The use of host’s PID namespace | hostPID
The use of host’s IPC namespace | hostIPC

By default, all hostNetwork, hostPIC, and hostPID are set to false. 

Fixes # (issue)
closes #46 
##### Type of change

- [x] New feature :sparkles:
- [x] This change requires a documentation update :book:
- [x] Breaking changes :warning:
##### How Has This Been Tested?

- [x] TestHostNetworkTrueV1
- [x] TestHostIPCTrueV1
- [x] TestHostPIDTrueV1
- [x] TestHostIPCTrueV1
- [x] TestHostNetworkTrueAllowedV1
- [x] TestHostIPCTrueAllowedV1
- [x] TestHostPIDTrueAllowedV1
- [x] TestNamespacesMisconfiguredAllowV1
- [x] TestNamespacesAllTrueV1
- [x] TestNamespacesAllTrueAllowedV1
- [x] TestAllowNamespacesFromConfig
- [x] TestFixHostNetworkTrueV1
- [x] TestFixHostIPCTrueV1
- [x] TestFixHostPIDTrueV1
- [x] TestFixHostNetworkTrueAllowedV1
- [x] TestFixHostIPCTrueAllowedV1
- [x] TestFixHostPIDTrueAllowedV1
- [x] TestFixNamespacesMisconfiguredAllowV1
- [x] TestFixNamespacesAllTrueV1
- [x] TestFixNamespacesAllTrueAllowedV1

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
