### PR TITLE
update File is not a valid kubernetes manifest to return underlying parsing error

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -250,7 +250,7 @@ func getKubeResourcesManifest(filename string) (decoded []Resource, err error) {
 			decoded = append(decoded, obj)
 		} else {
 			if !isCommentSlice(b) {
-				err = fmt.Errorf("File is not a valid Kubernetes manifest")
+				err = fmt.Errorf("File is not a valid Kubernetes manifest: %v", err)
 				return decoded, err
 			}
 		}


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description
When using kubeaudit, I ran into a non-descriptive error `File is not a valid Kubernetes manifest`. 

To troubleshoot this issue, I edited the error log to report the underlying error, thought I would PR it back.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] make test
- [x] manual build I was using to get the error. The CRD object in https://github.com/gravitational/wormhole/blob/master/docs/generic-wormhole.yaml causes a yaml parsing error.

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
