### PR TITLE
Put back autofix logic for ClusterRole and Role

### DIFF
--- a/cmd/autofix_test.go
+++ b/cmd/autofix_test.go
@@ -486,7 +486,7 @@ func TestFindItemInMapSlice(t *testing.T) {
 	assert.Equal(-1, index)
 }
 
-func TestMapPairMatch(t *testing.T) {
+func TestEqualValueForKey(t *testing.T) {
 	assert := assert.New(t)
 
 	// same string
@@ -495,17 +495,17 @@ func TestMapPairMatch(t *testing.T) {
 		{Key: "k", Value: "v"},
 		{Key: "k2", Value: "v2"},
 	}
-	assert.True(mapPairMatch("k2", m1, m2))
+	assert.True(equalValueForKey("k2", m1, m2))
 
 	// different string
 	m1 = yaml.MapSlice{{Key: "k", Value: "v"}}
 	m2 = yaml.MapSlice{{Key: "k", Value: "v2"}}
-	assert.False(mapPairMatch("k2", m1, m2))
+	assert.False(equalValueForKey("k2", m1, m2))
 
 	// string and number
 	m1 = yaml.MapSlice{{Key: "k", Value: "2"}}
 	m2 = yaml.MapSlice{{Key: "k", Value: 2}}
-	assert.False(mapPairMatch("k", m1, m2))
+	assert.False(equalValueForKey("k", m1, m2))
 }
 
 func TestSequenceItemMatch(t *testing.T) {

--- a/cmd/autofix_util.go
+++ b/cmd/autofix_util.go
@@ -557,14 +557,17 @@ func sequenceItemMatch(sequenceKey string, item1, item2 yaml.SequenceItem) bool 
 
 	// ClusterRole.rules : PolicyRule.resources
 	// IngressSpec.rules : IngressRule.host
-	// IngressSpec.rules : IngressRule.http
 	// Role.rules : PolicyRule.resources
 	case "rules":
-		if val1, index1 := findItemInMapSlice("host", map1); index1 != -1 {
-			if val2, index2 := findItemInMapSlice("host", map2); index2 != -1 {
-				return val1.Value == val2.Value
-			}
-			return false
+		// ClusterRole.rules : PolicyRule.resources
+		// Role.rules : PolicyRule.resources
+		if mapPairMatch("resources", map1, map2) {
+			return true
+		}
+
+		// IngressSpec.rules : IngressRule.host
+		if mapPairMatch("host", map1, map2) {
+			return true
 		}
 
 	// ProjectedVolumeSource.sources

--- a/fixtures/autofix-all-resources-fixed_v1.yml
+++ b/fixtures/autofix-all-resources-fixed_v1.yml
@@ -296,6 +296,39 @@ spec:
   selector: null
 status: {}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # "namespace" omitted since ClusterRoles are not namespaced
+  name: secret-reader
+rules:
+- apiGroups:
+  - ""
+  # 1
+  resources:
+  - secrets
+  # 2
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-reader
+rules:
+# "" indicates the core API group
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/fixtures/autofix-all-resources_v1.yml
+++ b/fixtures/autofix-all-resources_v1.yml
@@ -223,3 +223,23 @@ spec:
       automountServiceAccountToken: false
   selector: null
 status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # "namespace" omitted since ClusterRoles are not namespaced
+  name: secret-reader
+rules:
+- apiGroups: [""]
+  resources: ["secrets"] # 1
+  verbs: ["get", "watch", "list"] # 2
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: pod-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The logic for matching ClusterRole.rules and Role.rules was removed as part of https://github.com/Shopify/kubeaudit/pull/206/files#diff-3fd80df8ad953804dabe08fbffd8999fL562. It was unrelated to the bug that PR was meant to fix. IngressSpec.rules does not have a `resources` field thus putting it back is not a regression.

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Ran autofix on fixtures/autofix-all-resources_v1.yaml and made sure comments did not disappear, and that Ingress.spec.tls.rules `host` values were not changed (which would be a regression)

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease