### PR TITLE
add CLA link to Contributing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,3 +30,4 @@ Fixes # (issue)
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] The test coverage did not decrease
+- [ ] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)

--- a/.github/welcome.yml
+++ b/.github/welcome.yml
@@ -2,7 +2,7 @@ newIssueWelcomeComment: >
   Thanks for opening your first issue here! Be sure to follow the issue template!
 
 newPRWelcomeComment: >
-  Thanks for opening this pull request! Please check out our contributing guidelines and sign the CLA.
+  Thanks for opening this pull request! Please check out our [contributing guidelines](https://github.com/Shopify/kubeaudit#contribute) and [sign the CLA](https://cla.shopify.com/).
 
 firstPRMergeComment: >
   Congrats on merging your first pull request, keep em coming!

--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ If you'd like to fix a bug, contribute a feature or just correct a typo, please 
 1. Run the tests to see everything is working as expected: `make test`
 1. Commit your changes: `git commit -am 'Adds awesome feature'`
 1. Push to the branch: `git push fork`
+1. Sign the [Contributor License Agreement](https://cla.shopify.com/)
 1. Submit a PR (All PR must be labeled with :bug: (Bug fix), :sparkles: (New feature), :book: (Documentation update), or :warning: (Breaking changes) )
 1. ???
 1. Profit

--- a/README.md
+++ b/README.md
@@ -722,3 +722,5 @@ If you'd like to fix a bug, contribute a feature or just correct a typo, please 
 1. Submit a PR (All PR must be labeled with :bug: (Bug fix), :sparkles: (New feature), :book: (Documentation update), or :warning: (Breaking changes) )
 1. ???
 1. Profit
+
+Note that if you didn't sign the CLA before opening your PR, you can re-run the check by adding a comment to the PR that says "I've signed the CLA!"!


### PR DESCRIPTION
##### Description

Adds a link to the Contributor License Agreement in the Contributing section of the README!

##### Type of change

- [X] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:

##### How Has This Been Tested?

This is a documentation change and doesn't require testing!

##### Checklist:

- [X] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] The test coverage did not decrease