### PR TITLE
[Bug Fix] Change labels to valid syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,10 +447,10 @@ spec:
     metadata:
       labels:
         apps: YourAppNameHere
-        container.audit.kubernetes.io/<container-name>/allow-privilege-escalation: "YourReasonForOverrideHere"
+        container.audit.kubernetes.io/<container-name>.allow-privilege-escalation: "YourReasonForOverrideHere"
 ```
 
-Any label with a non-nil reason string will prevent `kubeaudit` from throwing the corresponding error and issue a warning instead.
+Any label with a non-nil reason string will prevent `kubeaudit` from throwing the corresponding error and issue a warning instead. Note that the reason may only contain alphanumeric characters and `.`, `_`, `-`, per Kubernetes label specification.
 Reasons matching `"true"` (not case sensitive) will be displayed as `Unspecified`.
 
 `kubeaudit` can skip certain audits by applying override labels to containers. If you want skip an audit for a specific container inside a pod, you can add an container override label. For example, if you use `kubeaudit` to ignore `allow-run-as-root` check for container "MyContainer1", you can add the following label:
@@ -461,7 +461,7 @@ spec:
     metadata:
       labels:
         apps: YourAppNameHere
-        container.audit.kubernetes.io/MyContainer1/allow-run-as-root: "YourReasonForOverrideHere"
+        container.audit.kubernetes.io/MyContainer1.allow-run-as-root: "YourReasonForOverrideHere"
 ```
 
 Similarly, you can have `kubeaudit` to skip a specific audit for all containers inside the pod by adding a pod override label. For example, if you use `kubeaudit` to ignore `allow-run-as-root` check for all containers inside the pod, you can add the following label:
@@ -472,7 +472,7 @@ spec:
     metadata:
       labels:
         apps: YourAppNameHere
-        audit.kubernetes.io/pod/allow-run-as-root: "YourReasonForOverrideHere"
+        audit.kubernetes.io/pod.allow-run-as-root: "YourReasonForOverrideHere"
 ```
 
 `kubeaudit` can also skip a specific audit for all network policies associated with a namespace resource
@@ -482,66 +482,66 @@ by adding a namespace override label. For example, if you use `kubeaudit` to ign
 metadata:
   name: namespaceName1
   labels:
-    audit.kubernetes.io/namespaceName1/allow-non-default-deny-egress-network-policy: "YourReasonForOverrideHere"
+    audit.kubernetes.io/namespaceName1.allow-non-default-deny-egress-network-policy: "YourReasonForOverrideHere"
 ```
 
 `kubeaudit` supports many labels on pod, namespace or container level:
-- [audit.kubernetes.io/pod/allow-privilege-escalation](#allowpe_label)
-- [container.audit.kubernetes.io/\<container-name\>/allow-privilege-escalation](#allowpe_label)
-- [audit.kubernetes.io/pod/allow-privileged](#priv_label)
-- [container.audit.kubernetes.io/\<container-name\>/allow-privileged](#priv_label)
-- [audit.kubernetes.io/pod/allow-capability](#caps_label)
-- [container.audit.kubernetes.io/\<container-name\>/allow-capability](#caps_label)
-- [audit.kubernetes.io/pod/allow-run-as-root](#nonroot_label)
-- [container.audit.kubernetes.io/\<container-name\>/allow-run-as-root](#nonroot_label)
-- [audit.kubernetes.io/pod/allow-automount-service-account-token](#sat_label)
-- [audit.kubernetes.io/pod/allow-read-only-root-filesystem-false](#rootfs_label)
-- [container.audit.kubernetes.io/\<container-name\>/allow-read-only-root-filesystem-false](#rootfs_label)
-- [audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-egress-network-policy](#egress_label)
-- [audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-ingress-network-policy](#ingress_label)
-- [audit.kubernetes.io/pod/allow-namespace-host-network](#namespacenetwork_label)
-- [audit.kubernetes.io/pod/allow-namespace-host-IPC](#namespaceipc_label)
-- [audit.kubernetes.io/pod/allow-namespace-host-PID](#namespacepid_label)
+- [audit.kubernetes.io/pod.allow-privilege-escalation](#allowpe_label)
+- [container.audit.kubernetes.io/\<container-name\>.allow-privilege-escalation](#allowpe_label)
+- [audit.kubernetes.io/pod.allow-privileged](#priv_label)
+- [container.audit.kubernetes.io/\<container-name\>.allow-privileged](#priv_label)
+- [audit.kubernetes.io/pod.allow-capability](#caps_label)
+- [container.audit.kubernetes.io/\<container-name\>.allow-capability](#caps_label)
+- [audit.kubernetes.io/pod.allow-run-as-root](#nonroot_label)
+- [container.audit.kubernetes.io/\<container-name\>.allow-run-as-root](#nonroot_label)
+- [audit.kubernetes.io/pod.allow-automount-service-account-token](#sat_label)
+- [audit.kubernetes.io/pod.allow-read-only-root-filesystem-false](#rootfs_label)
+- [container.audit.kubernetes.io/\<container-name\>.allow-read-only-root-filesystem-false](#rootfs_label)
+- [audit.kubernetes.io/\<namespace-name\>.allow-non-default-deny-egress-network-policy](#egress_label)
+- [audit.kubernetes.io/\<namespace-name\>.allow-non-default-deny-ingress-network-policy](#ingress_label)
+- [audit.kubernetes.io/pod.allow-namespace-host-network](#namespacenetwork_label)
+- [audit.kubernetes.io/pod.allow-namespace-host-IPC](#namespaceipc_label)
+- [audit.kubernetes.io/pod.allow-namespace-host-PID](#namespacepid_label)
 
 <a name="allowpe_label"/>
 
-### container.audit.kubernetes.io/\<container-name\>/allow-privilege-escalation
+### container.audit.kubernetes.io/\<container-name\>.allow-privilege-escalation
 
 Allow `allowPrivilegeEscalation` to be set to `true` to a specific container.
 
-### audit.kubernetes.io/pod/allow-privilege-escalation
+### audit.kubernetes.io/pod.allow-privilege-escalation
 
 Allows `allowPrivilegeEscalation` to be set to `true` to all the containers in a pod.
 
 ```sh
-kubeaudit.allow.privilegeEscalation: "Superuser privileges needed"
+kubeaudit.allow.privilegeEscalation: "SuperuserPrivilegesNeeded"
 
-WARN[0000] Allowed setting AllowPrivilegeEscalation to true  Reason="Superuser privileges needed"
+WARN[0000] Allowed setting AllowPrivilegeEscalation to true  Reason="SuperuserPrivilegesNeeded"
 ```
 
 <a name="priv_label"/>
 
-### container.audit.kubernetes.io/\<container-name\>/allow-privileged
+### container.audit.kubernetes.io/\<container-name\>.allow-privileged
 
 Allow `privileged` to be set to `true` to a specific container.
 
-### audit.kubernetes.io/pod/allow-privileged
+### audit.kubernetes.io/pod.allow-privileged
 
 Allows `privileged` to be set to `true` to all the containers in a pod.
 
 ```sh
-kubeaudit.allow.privileged: "Privileged execution required"
+kubeaudit.allow.privileged: "PrivilegedExecutionRequired"
 
-WARN[0000] Allowed setting privileged to true                Reason="Privileged execution required"
+WARN[0000] Allowed setting privileged to true                Reason="PrivilegedExecutionRequired"
 ```
 
 <a name="caps_label"/>
 
-### container.audit.kubernetes.io/\<container-name\>/allow-capability
+### container.audit.kubernetes.io/\<container-name\>.allow-capability
 
 Allows adding a capability or keeping one that would otherwise be dropped to a specific container.
 
-### audit.kubernetes.io/pod/allow-capability
+### audit.kubernetes.io/pod.allow-capability
 
 Allows adding a capability or keeping one that would otherwise be dropped to all the containers in a pod.
 
@@ -553,23 +553,23 @@ WARN[0000] Capability allowed                                CapName=CHOWN Reaso
 
 <a name="nonroot_label"/>
 
-### container.audit.kubernetes.io/\<container-name\>/allow-run-as-root
+### container.audit.kubernetes.io/\<container-name\>.allow-run-as-root
 
 Allows setting `runAsNonRoot` to `false` to a specific container.
 
-### audit.kubernetes.io/pod/allow-run-as-root
+### audit.kubernetes.io/pod.allow-run-as-root
 
 Allows setting `runAsNonRoot` to `false` to all the containers in a pod.
 
 ```sh
-kubeaudit.allow.runAsRoot: "Root privileges needed"
+kubeaudit.allow.runAsRoot: "RootPrivilegesNeeded"
 
-WARN[0000] Allowed setting RunAsNonRoot to false             Reason="Root privileges needed"
+WARN[0000] Allowed setting RunAsNonRoot to false             Reason="RootPrivilegesNeeded"
 ```
 
 <a name="sat_label"/>
 
-### audit.kubernetes.io/pod/allow-automount-service-account-token
+### audit.kubernetes.io/pod.allow-automount-service-account-token
 
 Allows setting `automountServiceAccountToken` to `true` to a pod.
 
@@ -581,66 +581,66 @@ WARN[0000] Allowed setting automountServiceAccountToken to true  Reason=Unspecif
 
 <a name="rootfs_label"/>
 
-### container.audit.kubernetes.io/\<container-name\>/allow-read-only-root-filesystem-false
+### container.audit.kubernetes.io/\<container-name\>.allow-read-only-root-filesystem-false
 
 Allows setting `readOnlyRootFilesystem` to `false` to a specific container.
 
-### audit.kubernetes.io/pod/allow-read-only-root-filesystem-false
+### audit.kubernetes.io/pod.allow-read-only-root-filesystem-false
 
 Allows setting `readOnlyRootFilesystem` to `false` to all containers in a pod.
 
 ```sh
-kubeaudit.allow.readOnlyRootFilesystemFalse: "Write permissions needed"
+kubeaudit.allow.readOnlyRootFilesystemFalse: "WritePermissionsNeeded"
 
-WARN[0000] Allowed setting readOnlyRootFilesystem to false Reason="Write permissions needed"
+WARN[0000] Allowed setting readOnlyRootFilesystem to false Reason="WritePermissionsNeeded"
 ```
 
 <a name="egress_label"/>
 
-### audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-egress-network-policy
+### audit.kubernetes.io/\<namespace-name\>.allow-non-default-deny-egress-network-policy
 
 Allows absense of `default-deny` egress network policy for that specific namespace.
 
 <a name="ingress_label"/>
 
-### audit.kubernetes.io/\<namespace-name\>/allow-non-default-deny-ingress-network-policy
+### audit.kubernetes.io/\<namespace-name\>.allow-non-default-deny-ingress-network-policy
 
 Allows absense of `default-deny` ingress network policy for that specific namespace.
 
 ```sh
-audit.kubernetes.io/default/allow-non-default-deny-egress-network-policy: "Egress is allowed"
+audit.kubernetes.io/default.allow-non-default-deny-egress-network-policy: "EgressIsAllowed"
 
-WARN[0000] Allowed Namespace without a default deny egress NetworkPolicy  KubeType=namespace Name=default Reason="Egress is allowed"
+WARN[0000] Allowed Namespace without a default deny egress NetworkPolicy  KubeType=namespace Name=default Reason="EgressIsAllowed"
 ```
 
 <a name="namespacenetwork_label"/>
 
-### audit.kubernetes.io/pod/allow-namespace-host-network
+### audit.kubernetes.io/pod.allow-namespace-host-network
 
 ```sh
-audit.kubernetes.io/pod/allow-namespace-host-network: "hostNetwork is allowed"
+audit.kubernetes.io/pod.allow-namespace-host-network: "HostNetworkIsAllowed"
 
-WARN[0000] Allowed setting hostNetwork to true           KubeType=pod Name=Pod Namespace=PodNamespace Reason="hostNetwork is allowed"
+WARN[0000] Allowed setting hostNetwork to true           KubeType=pod Name=Pod Namespace=PodNamespace Reason="HostNetworkIsAllowed"
 ```
 
 <a name="namespaceipc_label"/>
 
-### audit.kubernetes.io/pod/allow-namespace-host-IPC
+### audit.kubernetes.io/pod.allow-namespace-host-IPC
 
 ```sh
-audit.kubernetes.io/pod/allow-namespace-host-IPC: "hostIPC is allowed"
+audit.kubernetes.io/pod.allow-namespace-host-IPC: "HostIPCIsAllowed"
 
-WARN[0000] Allowed setting hostIPC to true               KubeType=pod Name=Pod Namespace=PodNamespace Reason="hostIPC is allowed"
+WARN[0000] Allowed setting hostIPC to true               KubeType=pod Name=Pod Namespace=PodNamespace Reason="HostIPCIsAllowed"
 ```
 
 <a name="namespacepid_label"/>
 
-### audit.kubernetes.io/pod/allow-namespace-host-PID
+### audit.kubernetes.io/pod.allow-namespace-host-PID
 
 ```sh
-audit.kubernetes.io/pod/allow-namespace-host-PID: "hostPID is allowed"
+audit.kubernetes.io/pod.allow-namespace-host-PID: "HOSTPIDIsAllowed"
 
-WARN[0000] Allowed setting hostPID to true               KubeType=pod Name=Pod Namespace=PodNamespace Reason="hostPID is allowed"
+WARN[0000] Allowed setting hostPID to true               KubeType=pod Name=Pod Namespace=PodNamespace Reason="HOSTPIDIsAllowed"
 ```
 
 <a name="contribute" />

--- a/cmd/result.go
+++ b/cmd/result.go
@@ -94,12 +94,12 @@ func (res *Result) allowedCaps(container ContainerV1) (allowed map[CapabilityV1]
 
 	allowed = make(map[CapabilityV1]string)
 	for k, v := range res.Labels {
-		if strings.Contains(k, "audit.kubernetes.io/pod/allow-capability-") {
-			capName := strings.Replace(strings.ToUpper(strings.TrimPrefix(k, "audit.kubernetes.io/pod/allow-capability-")), "-", "_", -1)
+		if strings.Contains(k, "audit.kubernetes.io/pod.allow-capability-") {
+			capName := strings.Replace(strings.ToUpper(strings.TrimPrefix(k, "audit.kubernetes.io/pod.allow-capability-")), "-", "_", -1)
 			allowed[CapabilityV1(capName)] = v
 		}
 
-		containerKeyString := "container.audit.kubernetes.io/" + container.Name + "/allow-capability-"
+		containerKeyString := "container.audit.kubernetes.io/" + container.Name + ".allow-capability-"
 		if strings.Contains(k, containerKeyString) {
 			capName := strings.Replace(strings.ToUpper(strings.TrimPrefix(k, containerKeyString)), "-", "_", -1)
 			allowed[CapabilityV1(capName)] = v

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -372,7 +372,7 @@ func shouldAuditCSC(podSpec PodSpecV1, container ContainerV1) bool {
 }
 
 func getContainerOverrideLabelReason(result *Result, container ContainerV1, overrideLabel string) (bool, string) {
-	containerOverrideLabel := "container.audit.kubernetes.io/" + container.Name + "/" + overrideLabel
+	containerOverrideLabel := "container.audit.kubernetes.io/" + container.Name + "." + overrideLabel
 
 	if reason := result.Labels[containerOverrideLabel]; reason != "" {
 		return true, reason
@@ -381,7 +381,7 @@ func getContainerOverrideLabelReason(result *Result, container ContainerV1, over
 }
 
 func getPodOverrideLabelReason(result *Result, overrideLabel string) (bool, string) {
-	podOverrideLabel := "audit.kubernetes.io/pod/" + overrideLabel
+	podOverrideLabel := "audit.kubernetes.io/pod." + overrideLabel
 	if reason := result.Labels[podOverrideLabel]; reason != "" {
 		return true, reason
 	}
@@ -410,11 +410,11 @@ func getNamespaceOverrideLabelReason(result *Result, nsName string, policyType s
 	var namespaceOverrideLabel string
 	var tempLabel string
 	if policyType == "egress" {
-		namespaceOverrideLabel = "audit.kubernetes.io/" + nsName + "/" + "allow-non-default-deny-egress-network-policy"
+		namespaceOverrideLabel = "audit.kubernetes.io/" + nsName + "." + "allow-non-default-deny-egress-network-policy"
 		tempLabel = "allow-non-default-deny-egress-network-policy"
 	}
 	if policyType == "ingress" {
-		namespaceOverrideLabel = "audit.kubernetes.io/" + nsName + "/" + "allow-non-default-deny-ingress-network-policy"
+		namespaceOverrideLabel = "audit.kubernetes.io/" + nsName + "." + "allow-non-default-deny-ingress-network-policy"
 		tempLabel = "allow-non-default-deny-ingress-network-policy"
 	}
 	if reason := result.Labels[namespaceOverrideLabel]; reason != "" {
@@ -444,11 +444,11 @@ func getNamespaceOverrideLabelReason(result *Result, nsName string, policyType s
 
 func isDefinedCapOverrideLabel(result *Result, container ContainerV1, capName string) bool {
 	capNameKey := strings.Replace(capName, "_", "-", -1)
-	containerKeyString := "container.audit.kubernetes.io/" + container.Name + "/allow-capability-" + capNameKey
+	containerKeyString := "container.audit.kubernetes.io/" + container.Name + ".allow-capability-" + capNameKey
 	if result.Labels[containerKeyString] != "" {
 		return true
 	}
 
-	podKeyString := "audit.kubernetes.io/pod/allow-capability-" + capNameKey
+	podKeyString := "audit.kubernetes.io/pod.allow-capability-" + capNameKey
 	return result.Labels[podKeyString] != ""
 }

--- a/fixtures/allow_privilege_escalation_misconfigured_allow_v1.yml
+++ b/fixtures/allow_privilege_escalation_misconfigured_allow_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeAllowPrivilegeEscalation
-        audit.kubernetes.io/pod/allow-privilege-escalation: "Superuser privileges needed"
+        audit.kubernetes.io/pod.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
       - name: fakeContainerAPE

--- a/fixtures/allow_privilege_escalation_misconfigured_allow_v1beta1.yml
+++ b/fixtures/allow_privilege_escalation_misconfigured_allow_v1beta1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeAllowPrivilegeEscalation
-        audit.kubernetes.io/pod/allow-privilege-escalation: "Superuser privileges needed"
+        audit.kubernetes.io/pod.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
       - name: fakeContainerAPE

--- a/fixtures/allow_privilege_escalation_true_allowed_v1.yml
+++ b/fixtures/allow_privilege_escalation_true_allowed_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeAllowPrivilegeEscalation
-        audit.kubernetes.io/pod/allow-privilege-escalation: "Superuser privileges needed"
+        audit.kubernetes.io/pod.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
       - name: fakeContainerAPE

--- a/fixtures/allow_privilege_escalation_true_allowed_v1beta1.yml
+++ b/fixtures/allow_privilege_escalation_true_allowed_v1beta1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeAllowPrivilegeEscalation
-        audit.kubernetes.io/pod/allow-privilege-escalation: "Superuser privileges needed"
+        audit.kubernetes.io/pod.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
       - name: fakeContainerAPE

--- a/fixtures/allow_privilege_escalation_true_multiple_allowed_multiple_containers_v1beta.yml
+++ b/fixtures/allow_privilege_escalation_true_multiple_allowed_multiple_containers_v1beta.yml
@@ -9,8 +9,8 @@ spec:
     metadata:
       labels:
         apps: fakeAllowPrivilegeEscalation
-        container.audit.kubernetes.io/fakeContainerAPE/allow-privilege-escalation: "Superuser privileges needed"
-        container.audit.kubernetes.io/fakeContainerAPE2/allow-privilege-escalation: "Superuser privileges needed"
+        container.audit.kubernetes.io/fakeContainerAPE.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
+        container.audit.kubernetes.io/fakeContainerAPE2.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
       - name: fakeContainerAPE

--- a/fixtures/allow_privilege_escalation_true_single_allowed_multiple_containers_v1beta.yml
+++ b/fixtures/allow_privilege_escalation_true_single_allowed_multiple_containers_v1beta.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeAllowPrivilegeEscalation
-        container.audit.kubernetes.io/fakeContainerAPE2/allow-privilege-escalation: "Superuser privileges needed"
+        container.audit.kubernetes.io/fakeContainerAPE2.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
       - name: fakeContainerAPE

--- a/fixtures/allowed_namespace_missing_default_deny_egress_netpol.yml
+++ b/fixtures/allowed_namespace_missing_default_deny_egress_netpol.yml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: "default"
   labels:
-    audit.kubernetes.io/default/allow-non-default-deny-egress-network-policy: "Egress is allowed"
+    audit.kubernetes.io/default.allow-non-default-deny-egress-network-policy: "SomeReason"
 ---
 # https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic
 apiVersion: networking.k8s.io/v1

--- a/fixtures/allowed_namespace_missing_default_deny_ingress_netpol.yml
+++ b/fixtures/allowed_namespace_missing_default_deny_ingress_netpol.yml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: "default"
   labels:
-    audit.kubernetes.io/default/allow-non-default-deny-ingress-network-policy: "Ingress is allowed"
+    audit.kubernetes.io/default.allow-non-default-deny-ingress-network-policy: "SomeReason"
 ---
 # https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic
 apiVersion: networking.k8s.io/v1

--- a/fixtures/allowed_namespace_missing_default_deny_netpol.yml
+++ b/fixtures/allowed_namespace_missing_default_deny_netpol.yml
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
   name: "default"
   labels:
-    audit.kubernetes.io/default/allow-non-default-deny-egress-network-policy: "Just for fun"
-    audit.kubernetes.io/default/allow-non-default-deny-ingress-network-policy: "Just for fun as well"
+    audit.kubernetes.io/default.allow-non-default-deny-egress-network-policy: "SomeReason"
+    audit.kubernetes.io/default.allow-non-default-deny-ingress-network-policy: "SomeReason"
 ---
 # https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/07-allow-traffic-from-some-pods-in-another-namespace.md
 kind: NetworkPolicy

--- a/fixtures/capabilities_misconfigured_allow_v1beta2.yml
+++ b/fixtures/capabilities_misconfigured_allow_v1beta2.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeSecurityContext
-        audit.kubernetes.io/pod/allow-capability-sys-time: "Time is of the essence"
+        audit.kubernetes.io/pod.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
       - name: fakeContainerSC

--- a/fixtures/capabilities_some_allowed_multi_containers_all_container_labels_v1beta2.yml
+++ b/fixtures/capabilities_some_allowed_multi_containers_all_container_labels_v1beta2.yml
@@ -9,10 +9,10 @@ spec:
     metadata:
       labels:
         apps: fakeSecurityContext
-        container.audit.kubernetes.io/fakeContainerSC/allow-capability-chown: 'True'
-        container.audit.kubernetes.io/fakeContainerSC/allow-capability-sys-time: 'Time is of the essence'
-        container.audit.kubernetes.io/fakeContainerSC2/allow-capability-chown: 'True'
-        container.audit.kubernetes.io/fakeContainerSC2/allow-capability-sys-time: 'Time is of the essence'
+        container.audit.kubernetes.io/fakeContainerSC.allow-capability-chown: "SomeReason"
+        container.audit.kubernetes.io/fakeContainerSC.allow-capability-sys-time: "SomeReason"
+        container.audit.kubernetes.io/fakeContainerSC2.allow-capability-chown: "SomeReason"
+        container.audit.kubernetes.io/fakeContainerSC2.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
         - name: fakeContainerSC

--- a/fixtures/capabilities_some_allowed_multi_containers_mix_labels_v1beta2.yml
+++ b/fixtures/capabilities_some_allowed_multi_containers_mix_labels_v1beta2.yml
@@ -9,10 +9,10 @@ spec:
     metadata:
       labels:
         apps: fakeSecurityContext
-        audit.kubernetes.io/pod/allow-capability-chown: "True"
-        container.audit.kubernetes.io/fakeContainerSC/allow-capability-chown: "True"
-        container.audit.kubernetes.io/fakeContainerSC/allow-capability-sys-time: "Time is of the essence"
-        container.audit.kubernetes.io/fakeContainerSC2/allow-capability-sys-time: "Time is of the essence"
+        audit.kubernetes.io/pod.allow-capability-chown: "True"
+        container.audit.kubernetes.io/fakeContainerSC.allow-capability-chown: "True"
+        container.audit.kubernetes.io/fakeContainerSC.allow-capability-sys-time: "SomeReason"
+        container.audit.kubernetes.io/fakeContainerSC2.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
       - name: fakeContainerSC

--- a/fixtures/capabilities_some_allowed_multi_containers_some_container_labels_v1beta2.yml
+++ b/fixtures/capabilities_some_allowed_multi_containers_some_container_labels_v1beta2.yml
@@ -9,8 +9,8 @@ spec:
     metadata:
       labels:
         apps: fakeSecurityContext
-        container.audit.kubernetes.io/fakeContainerSC/allow-capability-chown: "True"
-        container.audit.kubernetes.io/fakeContainerSC/allow-capability-sys-time: "Time is of the essence"
+        container.audit.kubernetes.io/fakeContainerSC.allow-capability-chown: "True"
+        container.audit.kubernetes.io/fakeContainerSC.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
       - name: fakeContainerSC

--- a/fixtures/capabilities_some_allowed_v1beta2.yml
+++ b/fixtures/capabilities_some_allowed_v1beta2.yml
@@ -9,8 +9,8 @@ spec:
     metadata:
       labels:
         apps: fakeSecurityContext
-        audit.kubernetes.io/pod/allow-capability-chown: "True"
-        audit.kubernetes.io/pod/allow-capability-sys-time: "Time is of the essence"
+        audit.kubernetes.io/pod.allow-capability-chown: "True"
+        audit.kubernetes.io/pod.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
       - name: fakeContainerSC

--- a/fixtures/host_IPC_true_allowed_v1.yml
+++ b/fixtures/host_IPC_true_allowed_v1.yml
@@ -4,7 +4,7 @@ metadata:
     name: Pod
     namespace: PodNamespace
     labels:
-        audit.kubernetes.io/pod/allow-namespace-host-IPC: "some reason"
+        audit.kubernetes.io/pod.allow-namespace-host-IPC: "SomeReason"
 spec:
     containers:
     - name: container

--- a/fixtures/host_PID_true_allowed_v1.yml
+++ b/fixtures/host_PID_true_allowed_v1.yml
@@ -4,7 +4,7 @@ metadata:
     name: Pod
     namespace: PodNamespace
     labels:
-        audit.kubernetes.io/pod/allow-namespace-host-PID: "some reason"
+        audit.kubernetes.io/pod.allow-namespace-host-PID: "SomeReason"
 spec:
     containers:
     - name: container

--- a/fixtures/host_network_true_allowed_v1.yml
+++ b/fixtures/host_network_true_allowed_v1.yml
@@ -4,7 +4,7 @@ metadata:
     name: Pod
     namespace: PodNamespace
     labels:
-        audit.kubernetes.io/pod/allow-namespace-host-network: "some reason"
+        audit.kubernetes.io/pod.allow-namespace-host-network: "SomeReason"
 spec:
     containers:
     - name: container

--- a/fixtures/namespaces_all_true_allowed_v1.yml
+++ b/fixtures/namespaces_all_true_allowed_v1.yml
@@ -4,9 +4,9 @@ metadata:
     name: Pod
     namespace: PodNamespace
     labels:
-        audit.kubernetes.io/pod/allow-namespace-host-network: "some reason"
-        audit.kubernetes.io/pod/allow-namespace-host-IPC: "some reason"
-        audit.kubernetes.io/pod/allow-namespace-host-PID: "some reason"
+        audit.kubernetes.io/pod.allow-namespace-host-network: "SomeReason"
+        audit.kubernetes.io/pod.allow-namespace-host-IPC: "SomeReason"
+        audit.kubernetes.io/pod.allow-namespace-host-PID: "SomeReason"
 spec:
     containers:
     - name: container

--- a/fixtures/namespaces_misconfigured_allow_v1.yml
+++ b/fixtures/namespaces_misconfigured_allow_v1.yml
@@ -4,7 +4,7 @@ metadata:
     name: Pod
     namespace: PodNamespace
     labels:
-        audit.kubernetes.io/pod/allow-namespace-host-network: "some reason"
+        audit.kubernetes.io/pod.allow-namespace-host-network: "SomeReason"
 spec:
     containers:
     - name: container

--- a/fixtures/privileged_misconfigured_allow_v1.yml
+++ b/fixtures/privileged_misconfigured_allow_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakePrivileged
-        audit.kubernetes.io/pod/allow-privileged: "Privileged execution required"
+        audit.kubernetes.io/pod.allow-privileged: "SomeReason"
     spec:
       containers:
       - name: fakeContainerPrivileged

--- a/fixtures/privileged_true_allowed_multi_containers_multi_labels_v1.yml
+++ b/fixtures/privileged_true_allowed_multi_containers_multi_labels_v1.yml
@@ -9,8 +9,8 @@ spec:
     metadata:
       labels:
         apps: fakePrivileged
-        container.audit.kubernetes.io/fakeContainerPrivileged/allow-privileged: "Privileged execution required"
-        container.audit.kubernetes.io/fakeContainerPrivileged2/allow-privileged: "Privileged execution required"
+        container.audit.kubernetes.io/fakeContainerPrivileged.allow-privileged: "SomeReason"
+        container.audit.kubernetes.io/fakeContainerPrivileged2.allow-privileged: "SomeReason"
     spec:
       containers:
       - name: fakeContainerPrivileged

--- a/fixtures/privileged_true_allowed_multi_containers_single_label_v1.yml
+++ b/fixtures/privileged_true_allowed_multi_containers_single_label_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakePrivileged
-        container.audit.kubernetes.io/fakeContainerPrivileged2/allow-privileged: "Privileged execution required"
+        container.audit.kubernetes.io/fakeContainerPrivileged2.allow-privileged: "SomeReason"
     spec:
       containers:
       - name: fakeContainerPrivileged

--- a/fixtures/privileged_true_allowed_v1.yml
+++ b/fixtures/privileged_true_allowed_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakePrivileged
-        audit.kubernetes.io/pod/allow-privileged: "Privileged execution required"
+        audit.kubernetes.io/pod.allow-privileged: "SomeReason"
     spec:
       containers:
       - name: fakeContainerPrivileged

--- a/fixtures/read_only_root_filesystem_false_allowed_multi_container_multi_labels_v1.yml
+++ b/fixtures/read_only_root_filesystem_false_allowed_multi_container_multi_labels_v1.yml
@@ -9,8 +9,8 @@ spec:
     metadata:
       labels:
         apps: fakeReadOnlyRootFilesystem
-        container.audit.kubernetes.io/fakeContainerRORF/allow-read-only-root-filesystem-false: "Write permissions needed"
-        container.audit.kubernetes.io/fakeContainerRORF2/allow-read-only-root-filesystem-false: "Write permissions needed"
+        container.audit.kubernetes.io/fakeContainerRORF.allow-read-only-root-filesystem-false: "SomeReason"
+        container.audit.kubernetes.io/fakeContainerRORF2.allow-read-only-root-filesystem-false: "SomeReason"
     spec:
       containers:
       - name: fakeContainerRORF

--- a/fixtures/read_only_root_filesystem_false_allowed_multi_container_single_label_v1.yml
+++ b/fixtures/read_only_root_filesystem_false_allowed_multi_container_single_label_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeReadOnlyRootFilesystem
-        container.audit.kubernetes.io/fakeContainerRORF1/allow-read-only-root-filesystem-false: "Write permissions needed"
+        container.audit.kubernetes.io/fakeContainerRORF1.allow-read-only-root-filesystem-false: "SomeReason"
     spec:
       containers:
       - name: fakeContainerRORF2

--- a/fixtures/read_only_root_filesystem_false_allowed_v1.yml
+++ b/fixtures/read_only_root_filesystem_false_allowed_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeReadOnlyRootFilesystem
-        audit.kubernetes.io/pod/allow-read-only-root-filesystem-false: "Write permissions needed"
+        audit.kubernetes.io/pod.allow-read-only-root-filesystem-false: "SomeReason"
     spec:
       containers:
       - name: fakeContainerRORF

--- a/fixtures/read_only_root_filesystem_misconfigured_allow_v1.yml
+++ b/fixtures/read_only_root_filesystem_misconfigured_allow_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeReadOnlyRootFilesystem
-        audit.kubernetes.io/pod/allow-read-only-root-filesystem-false: "Write permissions needed"
+        audit.kubernetes.io/pod.allow-read-only-root-filesystem-false: "SomeReason"
     spec:
       containers:
       - name: fakeContainerRORF

--- a/fixtures/run_as_non_root_false_allowed_v1.yml
+++ b/fixtures/run_as_non_root_false_allowed_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeSecurityContext
-        audit.kubernetes.io/pod/allow-run-as-root: "Superuser privileges needed"
+        audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
     spec:
       containers:
       - name: fakeContainerRANR

--- a/fixtures/run_as_non_root_misconfigured_allow_container_v1.yml
+++ b/fixtures/run_as_non_root_misconfigured_allow_container_v1.yml
@@ -10,7 +10,7 @@ spec:
       creationTimestamp: null
       labels:
         apps: fakeSecurityContext
-        audit.kubernetes.io/pod/allow-run-as-root: "Superuser privileges needed"
+        audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
     spec:
       containers:
       - name: fakeContainerRANR

--- a/fixtures/run_as_non_root_misconfigured_allow_pod_v1.yml
+++ b/fixtures/run_as_non_root_misconfigured_allow_pod_v1.yml
@@ -5,7 +5,7 @@ metadata:
   name: run_as_non_root_false
   labels:
     apps: fakeSecurityContext
-    audit.kubernetes.io/pod/allow-run-as-root: "Superuser privileges needed"
+    audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: fakeDeploymentRANR  
 spec:
   hostname: fakeRANR

--- a/fixtures/run_as_non_root_psc_false_allowed_multi_containers_multi_labels_v1.yml
+++ b/fixtures/run_as_non_root_psc_false_allowed_multi_containers_multi_labels_v1.yml
@@ -5,8 +5,8 @@ metadata:
   name: run_as_non_root_false_allowed
   labels:
     apps: fakeSecurityContext
-    container.audit.kubernetes.io/fakeContainerRANR/allow-run-as-root: "Superuser privileges needed"
-    container.audit.kubernetes.io/fakeContainerRANR2/allow-run-as-root: "Superuser privileges needed"
+    container.audit.kubernetes.io/fakeContainerRANR.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    container.audit.kubernetes.io/fakeContainerRANR2.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: fakeDeploymentRANR  
 spec:
   securityContext:

--- a/fixtures/run_as_non_root_psc_false_allowed_multi_containers_single_label_v1.yml
+++ b/fixtures/run_as_non_root_psc_false_allowed_multi_containers_single_label_v1.yml
@@ -5,7 +5,7 @@ metadata:
   name: run_as_non_root_false_allowed
   labels:
     apps: fakeSecurityContext
-    container.audit.kubernetes.io/fakeContainerRANR/allow-run-as-root: "Superuser privileges needed"
+    container.audit.kubernetes.io/fakeContainerRANR.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: fakeDeploymentRANR  
 spec:
   securityContext:

--- a/fixtures/run_as_non_root_psc_false_allowed_v1.yml
+++ b/fixtures/run_as_non_root_psc_false_allowed_v1.yml
@@ -5,7 +5,7 @@ metadata:
   name: run_as_non_root_false_allowed
   labels:
     apps: fakeSecurityContext
-    audit.kubernetes.io/pod/allow-run-as-root: "Superuser privileges needed"    
+    audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"    
   namespace: fakeDeploymentRANR  
 spec:
   securityContext:

--- a/fixtures/service_account_token_misconfigured_allow_v1.yml
+++ b/fixtures/service_account_token_misconfigured_allow_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeAutomountServiceAccountToken
-        audit.kubernetes.io/pod/allow-automount-service-account-token: "True"
+        audit.kubernetes.io/pod.allow-automount-service-account-token: "True"
     spec:
       automountServiceAccountToken: false
       containers:

--- a/fixtures/service_account_token_true_allowed_v1.yml
+++ b/fixtures/service_account_token_true_allowed_v1.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       labels:
         apps: fakeAutomountServiceAccountToken
-        audit.kubernetes.io/pod/allow-automount-service-account-token: "True"
+        audit.kubernetes.io/pod.allow-automount-service-account-token: "True"
     spec:
       automountServiceAccountToken: true
       containers:


### PR DESCRIPTION
##### Description

Kubernetes label keys can only contain one `/` and values cannot contain spaces. This updates the labels used by kubeaudit to meet the requirements for valid labels.

Fixes #228 

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:

##### How Has This Been Tested?

- [x] Create a pod with the new label format and make sure `kubectl apply` works. Note that `kubectl apply --validate=true --dry-run=true` does NOT catch label errors and therefore is not enough to test this change

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
