### PR TITLE
Switch travis to Go 1.12 and 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
 
 script:
   - make setup

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS=$(shell build/ldflags.sh)
 
 # kubernetes client won't build with go<1.10
 GOVERSION:=$(shell go version | awk '{print $$3}')
-GOVERSION_MIN:=go1.11
+GOVERSION_MIN:=go1.12
 GOVERSION_CHECK=$(shell printf "%s\n%s\n" "$(GOVERSION)" "$(GOVERSION_MIN)" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | head -n 1)
 
 export GO111MODULE=on


### PR DESCRIPTION
##### Description

This switches Kubeaudit to Go1.12 and Go1.12 and ditches Go1.11


##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] New feature :sparkles:

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
