### PR TITLE
Fix bug where flags were used before initialization

### DIFF
--- a/cmd/commands/capabilities.go
+++ b/cmd/commands/capabilities.go
@@ -9,16 +9,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var capabilitiesConfig customCapabilitiesConfig
+var capabilitiesConfig capabilities.Config
 
-type customCapabilitiesConfig struct {
-	dropList string
-}
-
-func (conf customCapabilitiesConfig) ToConfig() capabilities.Config {
-	return capabilities.Config{
-		DropList: strings.Split(capabilitiesConfig.dropList, " "),
+func formatDropList() string {
+	var buffer bytes.Buffer
+	for _, cap := range capabilities.DefaultDropList {
+		buffer.WriteString("\n- ")
+		buffer.WriteString(cap)
 	}
+	return buffer.String()
 }
 
 var capabilitiesCmd = &cobra.Command{
@@ -34,24 +33,17 @@ An ERROR result is generated when a pod has a capability which is on the drop li
 Example usage:
 kubeaudit capabilities
 kubeaudit capabilities --drop "%s"`, formatDropList(), strings.Join(capabilities.DefaultDropList[:3], " ")),
-	Run: runAudit(capabilities.New(capabilitiesConfig.ToConfig())),
+	Run: func(cmd *cobra.Command, args []string) {
+		runAudit(capabilities.New(capabilitiesConfig))(cmd, args)
+	},
 }
 
-func formatDropList() string {
-	var buffer bytes.Buffer
-	for _, cap := range capabilities.DefaultDropList {
-		buffer.WriteString("\n- ")
-		buffer.WriteString(cap)
-	}
-	return buffer.String()
+func setCapabilitiesFlags(cmd *cobra.Command) {
+	cmd.Flags().VarP(newStringSliceValue(strings.Join(capabilities.DefaultDropList, " "), &capabilitiesConfig.DropList), "drop", "d",
+		"List of capabilities that should be dropped")
 }
 
 func init() {
 	RootCmd.AddCommand(capabilitiesCmd)
 	setCapabilitiesFlags(capabilitiesCmd)
-}
-
-func setCapabilitiesFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&capabilitiesConfig.dropList, "drop", "d", strings.Join(capabilities.DefaultDropList, " "),
-		"List of capabilities that should be dropped")
 }

--- a/cmd/commands/image.go
+++ b/cmd/commands/image.go
@@ -21,14 +21,16 @@ This command is also a root command, check 'kubeaudit image --help'.
 Example usage:
 kubeaudit image --image gcr.io/google_containers/echoserver:1.7
 kubeaudit image -i gcr.io/google_containers/echoserver:1.7`,
-	Run: runAudit(image.New(imageConfig)),
+	Run: func(cmd *cobra.Command, args []string) {
+		runAudit(image.New(imageConfig))(cmd, args)
+	},
+}
+
+func setImageFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&imageConfig.Image, "image", "i", "", "Image to check against")
 }
 
 func init() {
 	RootCmd.AddCommand(imageCmd)
 	setImageFlags(imageCmd)
-}
-
-func setImageFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&imageConfig.Image, "image", "i", "", "Image to check against")
 }

--- a/cmd/commands/limits.go
+++ b/cmd/commands/limits.go
@@ -1,21 +1,12 @@
 package commands
 
 import (
-	kubeaudit "github.com/Shopify/kubeaudit"
 	"github.com/Shopify/kubeaudit/auditors/limits"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var limitsConfig limits.Config
-
-func limitsAuditor() kubeaudit.Auditable {
-	auditor, err := limits.New(limitsConfig)
-	if err != nil {
-		log.Fatal("failed to create limits auditor")
-	}
-	return auditor
-}
 
 var limitsCmd = &cobra.Command{
 	Use:   "limits",
@@ -29,15 +20,21 @@ A WARN result is generated for each of the following cases:
 Example usage:
 kubeaudit limits
 kubeaudit limits --cpu 500m --memory 256Mi`,
-	Run: runAudit(limitsAuditor()),
-}
-
-func init() {
-	RootCmd.AddCommand(limitsCmd)
-	setLimitsFlags(limitsCmd)
+	Run: func(cmd *cobra.Command, args []string) {
+		auditor, err := limits.New(limitsConfig)
+		if err != nil {
+			log.Fatal("failed to create limits auditor")
+		}
+		runAudit(auditor)(cmd, args)
+	},
 }
 
 func setLimitsFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&limitsConfig.CPU, "cpu", "", "Max CPU limit")
 	cmd.Flags().StringVar(&limitsConfig.Memory, "memory", "", "Max memory limit")
+}
+
+func init() {
+	RootCmd.AddCommand(limitsCmd)
+	setLimitsFlags(limitsCmd)
 }

--- a/cmd/commands/util.go
+++ b/cmd/commands/util.go
@@ -1,0 +1,30 @@
+package commands
+
+import "strings"
+
+// Implements pflag.Value
+// Custom type so slice values can be represented as a space-separated list of strings in the flag value
+//
+// Example:
+//
+//     var vals []string
+//     defaultVals := []string{"default1", "default2"}
+//
+//     Flags().VarP(newStringSliceValue(strings.Join(defaultVals, " "), &vals), "flagname", "f", "Flag description")
+//
+type stringSliceValue []string
+
+func newStringSliceValue(val string, p *[]string) *stringSliceValue {
+	*p = strings.Split(val, " ")
+	return (*stringSliceValue)(p)
+}
+
+func (s *stringSliceValue) Set(val string) error {
+	*s = stringSliceValue(strings.Split(val, " "))
+	return nil
+}
+func (s *stringSliceValue) Type() string {
+	return "stringSlice"
+}
+
+func (s *stringSliceValue) String() string { return strings.Join(*s, " ") }


### PR DESCRIPTION
Fixes a bug where flag values for subcommands were being used before they were initialized so passing flags had no effect. Also renaming the `verbose` flag to `minSeverity`