### PR TITLE
import azure auth module for AKS

### DIFF
--- a/cmd/kubernetes.go
+++ b/cmd/kubernetes.go
@@ -9,8 +9,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // auth for GKE clusters
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // auth for OIDC
+	_ "k8s.io/client-go/plugin/pkg/client/auth/azure" // auth for AKS clusters
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"   // auth for GKE clusters
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"  // auth for OIDC
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description

We have an Azure Kubernetes cluster which has Azure authentication enabled. This failed silently in the latest stable release, `kubeaudit` just did nothing. Compiling from source led me to this:

```
FATA[0000] Could not get a kube client: No Auth Provider found for name "azure"
```

Turns out, supporting this is a simple import.

##### Type of change

New feature :sparkles:

##### How Has This Been Tested?

I ran `make build` and `./kubeaudit -c ~/.kube/aks.config all` to confirm it's working.

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)