### PR TITLE
feat(cli): return exit code 2 on error findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ See the specific [auditor docs](#auditors) for the auditor you wish to override 
 
 To learn more about labels, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 
+## CI/CD usage
+
+kubeaudit will return exit code `2` whenever any errors are being found, so it can stop your pipeline.
+If you do not want this to happen, run it as `kubeaudit all || true`
+
 ## Contributing
 
 If you'd like to fix a bug, contribute a feature or just correct a typo, please feel free to do so as long as you follow our [Code of Conduct](https://github.com/Shopify/kubeaudit/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The rest of this README will focus on how to use kubeaudit as a command line too
 * [Commands](#commands)
 * [Configuration File](#configuration-file)
 * [Override Errors](#override-errors)
+* [CI/CD Usage](#cicd-usage)
 * [Contributing](#contributing)
 
 ## Installation

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -73,6 +73,10 @@ func runAudit(auditable ...kubeaudit.Auditable) func(cmd *cobra.Command, args []
 		}
 
 		report.PrintResults(os.Stdout, minSeverity, formatter)
+
+		if report.HasErrors() {
+			os.Exit(2)
+		}
 	}
 }
 

--- a/kubeaudit.go
+++ b/kubeaudit.go
@@ -216,6 +216,18 @@ func (r *Report) Results() []Result {
 	return results
 }
 
+// HasErrors returns true if any findings have the level of Error
+func (r *Report) HasErrors() (errorsFound bool) {
+	for _, workloadResult := range r.Results() {
+		for _, auditResult := range workloadResult.GetAuditResults() {
+			if auditResult.Severity >= Error {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // PrintResults writes the audit results with a severity greater than or matching minSeverity in a human-readable
 // way to the provided writer
 func (r *Report) PrintResults(writer io.Writer, minSeverity int, formatter log.Formatter) {


### PR DESCRIPTION
##### Description

The audit command will now return exit code 2 whenever any findings are found that have the type ERROR.

Fixes #257 

##### How Has This Been Tested?

`make build`

##### Checklist:

- [ ] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
