### PR TITLE
Produce warning if apparmor annotation is invalid

### DIFF
--- a/auditors/apparmor/apparmor.go
+++ b/auditors/apparmor/apparmor.go
@@ -109,7 +109,7 @@ func auditPodAnnotations(resource k8stypes.Resource, containerNames []string) []
 		if !contains(containerNames, containerName) {
 			auditResults = append(auditResults, &kubeaudit.AuditResult{
 				Name:     AppArmorInvalidAnnotation,
-				Severity: kubeaudit.Warn,
+				Severity: kubeaudit.Error,
 				Message:  fmt.Sprintf("AppArmor annotation key refers to a container that doesn't exist. Remove the annotation '%s: %s'.", annotationKey, annotationValue),
 				Metadata: kubeaudit.Metadata{
 					"Container":  containerName,

--- a/auditors/apparmor/apparmor.go
+++ b/auditors/apparmor/apparmor.go
@@ -17,6 +17,9 @@ const (
 	AppArmorAnnotationMissing = "AppArmorAnnotationMissing"
 	// AppArmorDisabled occurs when the apparmor annotation is set to a bad value
 	AppArmorDisabled = "AppArmorDisabled"
+	// AppArmorInvalidAnnotation occurs when the apparmor annotation key refers to a container which doesn't exist. This will
+	// prevent the manifest from being applied to a cluster with AppArmor enabled.
+	AppArmorInvalidAnnotation = "AppArmorInvalidAnnotation"
 )
 
 // As of Jan 14, 2020 these constants are not in the K8s API package, but once they are they should be replaced
@@ -41,13 +44,17 @@ func New() *AppArmor {
 // Audit checks that AppArmor is enabled for all containers
 func (a *AppArmor) Audit(resource k8stypes.Resource, _ []k8stypes.Resource) ([]*kubeaudit.AuditResult, error) {
 	var auditResults []*kubeaudit.AuditResult
+	var containerNames []string
 
 	for _, container := range k8s.GetContainers(resource) {
+		containerNames = append(containerNames, container.Name)
 		auditResult := auditContainer(container, resource)
 		if auditResult != nil {
 			auditResults = append(auditResults, auditResult)
 		}
 	}
+
+	auditResults = append(auditResults, auditPodAnnotations(resource, containerNames)...)
 
 	return auditResults, nil
 }
@@ -92,6 +99,31 @@ func auditContainer(container *k8stypes.ContainerV1, resource k8stypes.Resource)
 	return nil
 }
 
+func auditPodAnnotations(resource k8stypes.Resource, containerNames []string) []*kubeaudit.AuditResult {
+	var auditResults []*kubeaudit.AuditResult
+	for annotationKey, annotationValue := range k8s.GetAnnotations(resource) {
+		if !strings.HasPrefix(annotationKey, ContainerAnnotationKeyPrefix) {
+			continue
+		}
+		containerName := strings.Split(annotationKey, "/")[1]
+		if !contains(containerNames, containerName) {
+			auditResults = append(auditResults, &kubeaudit.AuditResult{
+				Name:     AppArmorInvalidAnnotation,
+				Severity: kubeaudit.Warn,
+				Message:  fmt.Sprintf("AppArmor annotation key refers to a container that doesn't exist. Remove the annotation '%s: %s'.", annotationKey, annotationValue),
+				Metadata: kubeaudit.Metadata{
+					"Container":  containerName,
+					"Annotation": fmt.Sprintf("%s: %s", annotationKey, annotationValue),
+				},
+				PendingFix: &fix.ByRemovingPodAnnotation{
+					Key: annotationKey,
+				},
+			})
+		}
+	}
+	return auditResults
+}
+
 func isAppArmorAnnotationMissing(apparmorAnnotation string, annotations map[string]string) bool {
 	_, ok := annotations[apparmorAnnotation]
 	return !ok
@@ -109,4 +141,13 @@ func getContainerAnnotation(container *k8stypes.ContainerV1) string {
 func getProfileName(apparmorAnnotation string, annotations map[string]string) string {
 	profileName := annotations[apparmorAnnotation]
 	return profileName
+}
+
+func contains(arr []string, val string) bool {
+	for _, arrVal := range arr {
+		if arrVal == val {
+			return true
+		}
+	}
+	return false
 }

--- a/auditors/apparmor/apparmor_test.go
+++ b/auditors/apparmor/apparmor_test.go
@@ -19,8 +19,9 @@ func TestAuditAppArmor(t *testing.T) {
 	}{
 		{"apparmor-enabled.yml", nil, true},
 		{"apparmor-annotation-missing.yml", []string{AppArmorAnnotationMissing}, true},
-		// This is an invalid manifest so we should only test it in manifest mode as kubernetes will fail to apply it
+		// These are invalid manifests so we should only test it in manifest mode as kubernetes will fail to apply it
 		{"apparmor-disabled.yml", []string{AppArmorDisabled}, false},
+		{"apparmor-invalid-annotation.yml", []string{AppArmorInvalidAnnotation}, false},
 	}
 
 	for _, tc := range cases {
@@ -44,6 +45,7 @@ func TestFixAppArmor(t *testing.T) {
 		{"apparmor-enabled.yml", "localhost/something"},
 		{"apparmor-annotation-missing.yml", ProfileRuntimeDefault},
 		{"apparmor-disabled.yml", ProfileRuntimeDefault},
+		{"apparmor-invalid-annotation.yml", ProfileRuntimeDefault},
 	}
 
 	for _, tc := range cases {

--- a/auditors/apparmor/fixtures/apparmor-invalid-annotation.yml
+++ b/auditors/apparmor/fixtures/apparmor-invalid-annotation.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  namespace: apparmor-enabled
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container: runtime/default
+    container.apparmor.security.beta.kubernetes.io/container2: runtime/default
+spec:
+  containers:
+    - name: container
+      image: scratch

--- a/docs/auditors/apparmor.md
+++ b/docs/auditors/apparmor.md
@@ -17,6 +17,13 @@ $ kubeaudit apparmor -f "auditors/apparmor/fixtures/apparmor_annotation_missing_
 ERRO[0000] AppArmor annotation missing. The annotation 'container.apparmor.security.beta.kubernetes.io/AAcontainer' should be added.  AuditResultName=AppArmorAnnotationMissing Container=AAcontainer MissingAnnotation=container.apparmor.security.beta.kubernetes.io/AAcontainer
 ```
 
+If an apparmor annotation refers to a container which doesn't exist, `kubectl apply` will fail. Kubeaudit produces an error for this case:
+
+```
+$ kubeaudit apparmor -f "auditors/apparmor/fixtures/apparmor-invalid-annotation.yml"
+ERRO[0000] AppArmor annotation key refers to a container that doesn't exist. Remove the annotation 'container.apparmor.security.beta.kubernetes.io/container2: runtime/default'.  Annotation="container.apparmor.security.beta.kubernetes.io/container2: runtime/default" AuditResultName=AppArmorInvalidAnnotation Container=container
+```
+
 ## Explanation
 
 AppArmor is a Mandatory Access Control (MAC) system used by Linux.


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description

If an apparmor annotation references a container that doesn't exist, the manifest will fail to apply. This PR adds a warning for this case.

##### Type of change

<!-- Please delete options that are not relevant. --->
- [ ] Bug fix :bug:
- [x] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [ ] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
