### PR TITLE
feat(docker): build Docker images too

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.*
+docs/
+Makefile
+LICENSE
+*.md
+*.sh
+Dockerfile

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,11 @@ brews:
   install: bin.install "kubeaudit"
   homepage: "https://github.com/Shopify/kubeaudit"
   description: "kubeaudit audits Kubernetes clusters for common security controls"
+dockers:
+- image_templates:
+  - "shopify/kubeaudit:latest"
+  - "shopify/kubeaudit:{{ .Tag }}"
+  - "shopify/kubeaudit:v{{ .Major }}"
 builds:
 - goos:
   - linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN adduser -s /bin/true -u 1000 -D -h /app app \
 WORKDIR /go/src/app/
 
 COPY . ./
-RUN go build -ldflags '-w -s -extldflags "-static"' -o /go/bin/kubeaudit -v \
+RUN go build -ldflags '-w -s -extldflags "-static"' -o /go/bin/kubeaudit -v
 
 #
 # ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,42 @@
+FROM golang:1.15.0-alpine AS builder
+
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+
+# add ca certificates and timezone data files
+# hadolint ignore=DL3018
+RUN apk add -U --no-cache ca-certificates tzdata
+
+# add unprivileged user
+RUN adduser -s /bin/true -u 1000 -D -h /app app \
+  && sed -i -r "/^(app|root)/!d" /etc/group /etc/passwd \
+  && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
+
+WORKDIR /go/src/app/
+
+COPY . ./
+RUN go build -ldflags '-w -s -extldflags "-static"' -o /go/bin/kubeaudit -v \
+
+#
+# ---
+#
+
+# start with empty image
 FROM scratch
-COPY config /config
-COPY kubeaudit /
+
+# add-in our timezone data file
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# add-in our unprivileged user
+COPY --from=builder /etc/passwd /etc/group /etc/shadow /etc/
+
+# add-in our ca certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# add-in our application
+COPY --from=builder --chown=app /go/bin/kubeaudit /kubeaudit
+
+# from now on, run as the unprivileged user
+USER app
+
+# entrypoint
 ENTRYPOINT ["/kubeaudit"]


### PR DESCRIPTION
##### Description

This adds-in an updated Dockerfile and enables Docker image building & push to GitHub. :sparkles: 

##### Type of change

- [x] New feature :sparkles:

##### How Has This Been Tested?

- [x] `docker build -t kubeaudit .`

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
