### PR TITLE
Support automountServiceAccountToken on ServiceAccount

### DIFF
--- a/auditors/asat/asat.go
+++ b/auditors/asat/asat.go
@@ -15,6 +15,7 @@ const (
 	// AutomountServiceAccountTokenTrueAndDefaultSA occurs when automountServiceAccountToken is either not set
 	// (which defaults to true) or explicitly set to true, and serviceAccountName is either not set or set to "default"
 	AutomountServiceAccountTokenTrueAndDefaultSA = "AutomountServiceAccountTokenTrueAndDefaultSA"
+	AutomountServiceAccountTokenTrueForDefaultSA = "AutomountServiceAccountTokenTrueForDefaultSA"
 )
 
 const OverrideLabel = "allow-automount-service-account-token"
@@ -28,8 +29,8 @@ func New() *AutomountServiceAccountToken {
 
 // Audit checks that the deprecated serviceAccount field is not used and that the default service account is not
 // being automatically mounted
-func (a *AutomountServiceAccountToken) Audit(resource k8stypes.Resource, _ []k8stypes.Resource) ([]*kubeaudit.AuditResult, error) {
-	auditResult := auditResource(resource)
+func (a *AutomountServiceAccountToken) Audit(resource k8stypes.Resource, resources []k8stypes.Resource) ([]*kubeaudit.AuditResult, error) {
+	auditResult := auditResource(resource, resources)
 	auditResult = override.ApplyOverride(auditResult, "", resource, OverrideLabel)
 	if auditResult != nil {
 		return []*kubeaudit.AuditResult{auditResult}, nil
@@ -38,13 +39,13 @@ func (a *AutomountServiceAccountToken) Audit(resource k8stypes.Resource, _ []k8s
 	return nil, nil
 }
 
-func auditResource(resource k8stypes.Resource) *kubeaudit.AuditResult {
+func auditResource(resource k8stypes.Resource, resources []k8stypes.Resource) *kubeaudit.AuditResult {
 	podSpec := k8s.GetPodSpec(resource)
 	if podSpec == nil {
 		return nil
 	}
 
-	if isDeprecatedServiceAccountName(podSpec) && !isServiceAccountName(podSpec) {
+	if isDeprecatedServiceAccountName(podSpec) && !hasServiceAccountName(podSpec) {
 		return &kubeaudit.AuditResult{
 			Name:     AutomountServiceAccountTokenDeprecated,
 			Severity: kubeaudit.Warn,
@@ -58,13 +59,15 @@ func auditResource(resource k8stypes.Resource) *kubeaudit.AuditResult {
 		}
 	}
 
-	if isDefaultServiceAccountWithAutomountToken(podSpec) {
+	defaultServiceAccount := getDefaultServiceAccount(resources)
+	if usesDefaultServiceAccount(podSpec) && isAutomountTokenTrue(podSpec, defaultServiceAccount) {
 		return &kubeaudit.AuditResult{
 			Name:     AutomountServiceAccountTokenTrueAndDefaultSA,
 			Severity: kubeaudit.Error,
-			Message:  "Default service account with token mounted. automountServiceAccountToken should be set to 'false' or a non-default service account should be used.",
+			Message:  "Default service account with token mounted. automountServiceAccountToken should be set to 'false' on either the ServiceAccount or on the PodSpec or a non-default service account should be used.",
 			PendingFix: &fixDefaultServiceAccountWithAutomountToken{
-				podSpec: podSpec,
+				podSpec:               podSpec,
+				defaultServiceAccount: defaultServiceAccount,
 			},
 		}
 	}
@@ -76,18 +79,30 @@ func isDeprecatedServiceAccountName(podSpec *k8stypes.PodSpecV1) bool {
 	return podSpec.DeprecatedServiceAccount != ""
 }
 
-func isServiceAccountName(podSpec *k8stypes.PodSpecV1) bool {
+func hasServiceAccountName(podSpec *k8stypes.PodSpecV1) bool {
 	return podSpec.ServiceAccountName != ""
 }
 
-func isDefaultServiceAccountWithAutomountToken(podSpec *k8stypes.PodSpecV1) bool {
-	return isAutomountTokenTrue(podSpec) && isDefaultServiceAccount(podSpec)
+func isAutomountTokenTrue(podSpec *k8stypes.PodSpecV1, defaultServiceAccount *k8stypes.ServiceAccountV1) bool {
+	if podSpec.AutomountServiceAccountToken != nil {
+		return *podSpec.AutomountServiceAccountToken
+	}
+
+	return defaultServiceAccount == nil ||
+		defaultServiceAccount.AutomountServiceAccountToken == nil ||
+		*defaultServiceAccount.AutomountServiceAccountToken
 }
 
-func isAutomountTokenTrue(podSpec *k8stypes.PodSpecV1) bool {
-	return podSpec.AutomountServiceAccountToken == nil || *podSpec.AutomountServiceAccountToken
-}
-
-func isDefaultServiceAccount(podSpec *k8stypes.PodSpecV1) bool {
+func usesDefaultServiceAccount(podSpec *k8stypes.PodSpecV1) bool {
 	return podSpec.ServiceAccountName == "" || podSpec.ServiceAccountName == "default"
+}
+
+func getDefaultServiceAccount(resources []k8stypes.Resource) (serviceAccount *k8stypes.ServiceAccountV1) {
+	for _, resource := range resources {
+		serviceAccount, ok := resource.(*k8stypes.ServiceAccountV1)
+		if ok && (k8s.GetObjectMeta(serviceAccount).GetName() == "default") {
+			return serviceAccount
+		}
+	}
+	return
 }

--- a/auditors/asat/asat.go
+++ b/auditors/asat/asat.go
@@ -15,7 +15,6 @@ const (
 	// AutomountServiceAccountTokenTrueAndDefaultSA occurs when automountServiceAccountToken is either not set
 	// (which defaults to true) or explicitly set to true, and serviceAccountName is either not set or set to "default"
 	AutomountServiceAccountTokenTrueAndDefaultSA = "AutomountServiceAccountTokenTrueAndDefaultSA"
-	AutomountServiceAccountTokenTrueForDefaultSA = "AutomountServiceAccountTokenTrueForDefaultSA"
 )
 
 const OverrideLabel = "allow-automount-service-account-token"

--- a/auditors/asat/asat_test.go
+++ b/auditors/asat/asat_test.go
@@ -26,7 +26,10 @@ func TestAuditAutomountServiceAccountToken(t *testing.T) {
 			override.GetOverriddenResultName(AutomountServiceAccountTokenTrueAndDefaultSA)}, true,
 		},
 		{"service-account-token-true-and-default-name.yml", []string{AutomountServiceAccountTokenTrueAndDefaultSA}, true},
+		{"service-account-token-false.yml", []string{}, true},
 		{"service-account-token-redundant-override.yml", []string{kubeaudit.RedundantAuditorOverride}, true},
+		{"service-account-token-nil-and-no-name-and-default-sa.yml", []string{}, true},
+		{"service-account-token-true-and-default-sa.yml", []string{AutomountServiceAccountTokenTrueAndDefaultSA}, true},
 	}
 
 	for _, tc := range cases {

--- a/auditors/asat/fix_test.go
+++ b/auditors/asat/fix_test.go
@@ -10,37 +10,37 @@ import (
 )
 
 func TestFixAutomountServiceAccountToken(t *testing.T) {
-	// cases := []struct {
-	// 	file                             string
-	// 	expectedDeprecatedServiceAccount string
-	// 	expectedServiceAccountName       string
-	// 	expectedAutomountToken           *bool
-	// }{
-	// 	{"service-account-token-deprecated.yml", "", "deprecated", nil},
-	// 	{"service-account-token-nil-and-no-name.yml", "", "", k8s.NewFalse()},
-	// 	{"service-account-token-redundant-override.yml", "", "", k8s.NewFalse()},
-	// 	{"service-account-token-true-allowed.yml", "", "", k8s.NewTrue()},
-	// 	{"service-account-token-true-and-default-name.yml", "", "default", k8s.NewFalse()},
-	// 	{"service-account-token-true-and-no-name.yml", "", "", k8s.NewFalse()},
-	// 	{"service-account-token-false.yml", "", "", k8s.NewFalse()},
-	// }
+	cases := []struct {
+		file                             string
+		expectedDeprecatedServiceAccount string
+		expectedServiceAccountName       string
+		expectedAutomountToken           *bool
+	}{
+		{"service-account-token-deprecated.yml", "", "deprecated", nil},
+		{"service-account-token-nil-and-no-name.yml", "", "", k8s.NewFalse()},
+		{"service-account-token-redundant-override.yml", "", "", k8s.NewFalse()},
+		{"service-account-token-true-allowed.yml", "", "", k8s.NewTrue()},
+		{"service-account-token-true-and-default-name.yml", "", "default", k8s.NewFalse()},
+		{"service-account-token-true-and-no-name.yml", "", "", k8s.NewFalse()},
+		{"service-account-token-false.yml", "", "", k8s.NewFalse()},
+	}
 
-	// for _, tc := range cases {
-	// 	t.Run(tc.file, func(t *testing.T) {
-	// 		resources, _ := test.FixSetup(t, fixtureDir, tc.file, New())
-	// 		for _, resource := range resources {
-	// 			podSpec := k8s.GetPodSpec(resource)
-	// 			assert.Equal(t, tc.expectedDeprecatedServiceAccount, podSpec.DeprecatedServiceAccount)
-	// 			assert.Equal(t, tc.expectedServiceAccountName, podSpec.ServiceAccountName)
-	// 			if tc.expectedAutomountToken == nil {
-	// 				assert.Nil(t, podSpec.AutomountServiceAccountToken)
-	// 			} else {
-	// 				assert.Equal(t, *tc.expectedAutomountToken, *podSpec.AutomountServiceAccountToken)
-	// 			}
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			resources, _ := test.FixSetup(t, fixtureDir, tc.file, New())
+			for _, resource := range resources {
+				podSpec := k8s.GetPodSpec(resource)
+				assert.Equal(t, tc.expectedDeprecatedServiceAccount, podSpec.DeprecatedServiceAccount)
+				assert.Equal(t, tc.expectedServiceAccountName, podSpec.ServiceAccountName)
+				if tc.expectedAutomountToken == nil {
+					assert.Nil(t, podSpec.AutomountServiceAccountToken)
+				} else {
+					assert.Equal(t, *tc.expectedAutomountToken, *podSpec.AutomountServiceAccountToken)
+				}
 
-	// 		}
-	// 	})
-	// }
+			}
+		})
+	}
 
 	// Test that if a default ServiceAccount was found, its 'automountServiceAccountToken' is set to false
 	// instead of on the PodSpec

--- a/auditors/asat/fix_test.go
+++ b/auditors/asat/fix_test.go
@@ -5,37 +5,62 @@ import (
 
 	"github.com/Shopify/kubeaudit/internal/k8s"
 	"github.com/Shopify/kubeaudit/internal/test"
+	"github.com/Shopify/kubeaudit/k8stypes"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFixAutomountServiceAccountToken(t *testing.T) {
-	cases := []struct {
-		file                             string
-		expectedDeprecatedServiceAccount string
-		expectedServiceAccountName       string
-		expectedAutomountToken           *bool
-	}{
-		{"service-account-token-deprecated.yml", "", "deprecated", nil},
-		{"service-account-token-nil-and-no-name.yml", "", "", k8s.NewFalse()},
-		{"service-account-token-redundant-override.yml", "", "", k8s.NewFalse()},
-		{"service-account-token-true-allowed.yml", "", "", k8s.NewTrue()},
-		{"service-account-token-true-and-default-name.yml", "", "default", k8s.NewFalse()},
-		{"service-account-token-true-and-no-name.yml", "", "", k8s.NewFalse()},
-	}
+	// cases := []struct {
+	// 	file                             string
+	// 	expectedDeprecatedServiceAccount string
+	// 	expectedServiceAccountName       string
+	// 	expectedAutomountToken           *bool
+	// }{
+	// 	{"service-account-token-deprecated.yml", "", "deprecated", nil},
+	// 	{"service-account-token-nil-and-no-name.yml", "", "", k8s.NewFalse()},
+	// 	{"service-account-token-redundant-override.yml", "", "", k8s.NewFalse()},
+	// 	{"service-account-token-true-allowed.yml", "", "", k8s.NewTrue()},
+	// 	{"service-account-token-true-and-default-name.yml", "", "default", k8s.NewFalse()},
+	// 	{"service-account-token-true-and-no-name.yml", "", "", k8s.NewFalse()},
+	// 	{"service-account-token-false.yml", "", "", k8s.NewFalse()},
+	// }
 
-	for _, tc := range cases {
-		t.Run(tc.file, func(t *testing.T) {
-			resources, _ := test.FixSetup(t, fixtureDir, tc.file, New())
+	// for _, tc := range cases {
+	// 	t.Run(tc.file, func(t *testing.T) {
+	// 		resources, _ := test.FixSetup(t, fixtureDir, tc.file, New())
+	// 		for _, resource := range resources {
+	// 			podSpec := k8s.GetPodSpec(resource)
+	// 			assert.Equal(t, tc.expectedDeprecatedServiceAccount, podSpec.DeprecatedServiceAccount)
+	// 			assert.Equal(t, tc.expectedServiceAccountName, podSpec.ServiceAccountName)
+	// 			if tc.expectedAutomountToken == nil {
+	// 				assert.Nil(t, podSpec.AutomountServiceAccountToken)
+	// 			} else {
+	// 				assert.Equal(t, *tc.expectedAutomountToken, *podSpec.AutomountServiceAccountToken)
+	// 			}
+
+	// 		}
+	// 	})
+	// }
+
+	// Test that if a default ServiceAccount was found, its 'automountServiceAccountToken' is set to false
+	// instead of on the PodSpec
+	files := []string{
+		"service-account-token-nil-and-no-name-and-default-sa.yml",
+		"service-account-token-true-and-default-sa.yml",
+	}
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			resources, _ := test.FixSetup(t, fixtureDir, file, New())
 			for _, resource := range resources {
-				podSpec := k8s.GetPodSpec(resource)
-				assert.Equal(t, tc.expectedDeprecatedServiceAccount, podSpec.DeprecatedServiceAccount)
-				assert.Equal(t, tc.expectedServiceAccountName, podSpec.ServiceAccountName)
-				if tc.expectedAutomountToken == nil {
-					assert.Nil(t, podSpec.AutomountServiceAccountToken)
-				} else {
-					assert.Equal(t, *tc.expectedAutomountToken, *podSpec.AutomountServiceAccountToken)
+				if serviceAccount, ok := resource.(*k8stypes.ServiceAccountV1); ok {
+					assert.Equal(t, serviceAccount.AutomountServiceAccountToken, k8s.NewFalse())
+					continue
 				}
 
+				podSpec := k8s.GetPodSpec(resource)
+				assert.Equal(t, "", podSpec.DeprecatedServiceAccount)
+				assert.Equal(t, "", podSpec.ServiceAccountName)
+				assert.Nil(t, podSpec.AutomountServiceAccountToken)
 			}
 		})
 	}

--- a/auditors/asat/fixtures/service-account-token-false.yml
+++ b/auditors/asat/fixtures/service-account-token-false.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: replicationcontroller
+  namespace: service-account-token-false
+spec:
+  template:
+    metadata:
+      labels:
+        name: replicationcontroller
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: container
+          image: scratch

--- a/auditors/asat/fixtures/service-account-token-nil-and-no-name-and-default-sa.yml
+++ b/auditors/asat/fixtures/service-account-token-nil-and-no-name-and-default-sa.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: replicationcontroller
+  namespace: service-account-token-nil-and-no-name-and-default-sa
+spec:
+  template:
+    metadata:
+      labels:
+        name: replicationcontroller
+    spec:
+      containers:
+        - name: replicationcontroller
+          image: scratch
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/auditors/asat/fixtures/service-account-token-true-and-default-sa.yml
+++ b/auditors/asat/fixtures/service-account-token-true-and-default-sa.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: replicationcontroller
+  namespace: service-account-token-true-and-default-sa
+spec:
+  template:
+    metadata:
+      labels:
+        name: replicationcontroller
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - name: container
+          image: scratch
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+automountServiceAccountToken: false

--- a/auditors/netpols/netpols.go
+++ b/auditors/netpols/netpols.go
@@ -42,7 +42,7 @@ func New() *DefaultDenyNetworkPolicies {
 
 // Audit checks that each namespace resource has a default deny NetworkPolicy for all ingress and egress traffic
 func (a *DefaultDenyNetworkPolicies) Audit(resource k8stypes.Resource, resources []k8stypes.Resource) ([]*kubeaudit.AuditResult, error) {
-	if !isNamespaceResource(resource) {
+	if !k8stypes.IsNamespaceV1(resource) {
 		return nil, nil
 	}
 

--- a/auditors/netpols/util.go
+++ b/auditors/netpols/util.go
@@ -16,16 +16,6 @@ func getNetworkPolicies(resources []k8stypes.Resource, namespace string) (networ
 	return
 }
 
-func isNamespaceResource(resource k8stypes.Resource) bool {
-	_, ok := resource.(*k8stypes.NamespaceV1)
-	return ok
-}
-
-func isNetworkPolicyResource(resource k8stypes.Resource) bool {
-	_, ok := resource.(*k8stypes.NetworkPolicyV1)
-	return ok
-}
-
 // isNetworkPolicyType checks if the NetworkPolicy applies to the specified policy type (Ingress or Egress)
 func isNetworkPolicyType(netPol *k8stypes.NetworkPolicyV1, netPolType string) bool {
 	for _, polType := range netPol.Spec.PolicyTypes {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -304,7 +304,7 @@ func GetNetworkPolicies(clientset kubernetes.Interface, options ClientOptions) [
 	return netPols
 }
 
-// GetCronJobs gets all CronJob resources from the cluster
+// GetServiceAccounts gets all ServiceAccount resources from the cluster
 func GetServiceAccounts(clientset kubernetes.Interface, options ClientOptions) []k8stypes.Resource {
 	serviceAccountClient := clientset.CoreV1().ServiceAccounts(options.Namespace)
 	serviceAccountList, err := serviceAccountClient.List(context.Background(), k8stypes.ListOptionsV1{})

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -318,7 +318,8 @@ func GetServiceAccounts(clientset kubernetes.Interface, options ClientOptions) [
 	for _, serviceAccount := range serviceAccountList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
 		serviceAccount.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind: "NetworkPolicy",
+			Kind:    "ServiceAccount",
+			Version: "v1",
 		})
 		serviceAccounts = append(serviceAccounts, serviceAccount.DeepCopyObject())
 	}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Shopify/kubeaudit/k8stypes"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -128,11 +127,7 @@ func GetDaemonSets(clientset kubernetes.Interface, options ClientOptions) []k8st
 	daemonSets := make([]k8stypes.Resource, 0, len(daemonSetList.Items))
 	for _, daemonSet := range daemonSetList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		daemonSet.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "DaemonSet",
-			Group:   "apps",
-			Version: "v1",
-		})
+		daemonSet.TypeMeta = k8stypes.NewDaemonSet().TypeMeta
 		daemonSets = append(daemonSets, daemonSet.DeepCopyObject())
 	}
 
@@ -152,11 +147,7 @@ func GetDeployments(clientset kubernetes.Interface, options ClientOptions) []k8s
 	deployments := make([]k8stypes.Resource, 0, len(deploymentList.Items))
 	for _, deployment := range deploymentList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		deployment.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "Deployment",
-			Group:   "apps",
-			Version: "v1",
-		})
+		deployment.TypeMeta = k8stypes.NewDeployment().TypeMeta
 		deployments = append(deployments, (&deployment).DeepCopyObject())
 	}
 
@@ -176,10 +167,7 @@ func GetPods(clientset kubernetes.Interface, options ClientOptions) []k8stypes.R
 	pods := make([]k8stypes.Resource, 0, len(podList.Items))
 	for _, pod := range podList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		pod.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "Pod",
-			Version: "v1",
-		})
+		pod.TypeMeta = k8stypes.NewPod().TypeMeta
 		pods = append(pods, pod.DeepCopyObject())
 	}
 
@@ -199,10 +187,7 @@ func GetPodTemplates(clientset kubernetes.Interface, options ClientOptions) []k8
 	podTemplates := make([]k8stypes.Resource, 0, len(podTemplateList.Items))
 	for _, podTemplate := range podTemplateList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		podTemplate.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "PodTemplate",
-			Version: "v1",
-		})
+		podTemplate.TypeMeta = k8stypes.NewPodTemplate().TypeMeta
 		podTemplates = append(podTemplates, podTemplate.DeepCopyObject())
 	}
 
@@ -222,10 +207,7 @@ func GetReplicationControllers(clientset kubernetes.Interface, options ClientOpt
 	replicationControllers := make([]k8stypes.Resource, 0, len(replicationControllerList.Items))
 	for _, replicationController := range replicationControllerList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		replicationController.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "ReplicationController",
-			Version: "v1",
-		})
+		replicationController.TypeMeta = k8stypes.NewReplicationController().TypeMeta
 		replicationControllers = append(replicationControllers, replicationController.DeepCopyObject())
 	}
 
@@ -245,11 +227,7 @@ func GetStatefulSets(clientset kubernetes.Interface, options ClientOptions) []k8
 	statefulSets := make([]k8stypes.Resource, 0, len(statefulSetList.Items))
 	for _, statefulSet := range statefulSetList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		statefulSet.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "StatefulSet",
-			Group:   "apps",
-			Version: "v1",
-		})
+		statefulSet.TypeMeta = k8stypes.NewStatefulSet().TypeMeta
 		statefulSets = append(statefulSets, statefulSet.DeepCopyObject())
 	}
 
@@ -269,11 +247,7 @@ func GetCronJobs(clientset kubernetes.Interface, options ClientOptions) []k8styp
 	cronJobs := make([]k8stypes.Resource, 0, len(cronJobList.Items))
 	for _, cronJob := range cronJobList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		cronJob.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "CronJob",
-			Group:   "batch",
-			Version: "v1beta1",
-		})
+		cronJob.TypeMeta = k8stypes.NewCronJob().TypeMeta
 		cronJobs = append(cronJobs, cronJob.DeepCopyObject())
 	}
 
@@ -293,11 +267,7 @@ func GetNetworkPolicies(clientset kubernetes.Interface, options ClientOptions) [
 	netPols := make([]k8stypes.Resource, 0, len(netPolList.Items))
 	for _, netPol := range netPolList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		netPol.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "NetworkPolicy",
-			Group:   "networking.k8s.io",
-			Version: "v1",
-		})
+		netPol.TypeMeta = k8stypes.NewNetworkPolicy().TypeMeta
 		netPols = append(netPols, netPol.DeepCopyObject())
 	}
 
@@ -317,10 +287,7 @@ func GetServiceAccounts(clientset kubernetes.Interface, options ClientOptions) [
 	serviceAccounts := make([]k8stypes.Resource, 0, len(serviceAccountList.Items))
 	for _, serviceAccount := range serviceAccountList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		serviceAccount.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "ServiceAccount",
-			Version: "v1",
-		})
+		serviceAccount.TypeMeta = k8stypes.NewServiceAccount().TypeMeta
 		serviceAccounts = append(serviceAccounts, serviceAccount.DeepCopyObject())
 	}
 
@@ -347,10 +314,7 @@ func GetNamespaces(clientset kubernetes.Interface, options ClientOptions) []k8st
 	namespaces := make([]k8stypes.Resource, 0, len(namespaceList.Items))
 	for _, namespace := range namespaceList.Items {
 		// For some reason the kubernetes SDK doesn't populate the type meta so we populate it manually
-		namespace.SetGroupVersionKind(schema.GroupVersionKind{
-			Kind:    "Namespace",
-			Version: "v1",
-		})
+		namespace.TypeMeta = k8stypes.NewNamespace().TypeMeta
 		namespaces = append(namespaces, (&namespace).DeepCopyObject())
 	}
 

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -78,6 +78,7 @@ func TestGetAllResources(t *testing.T) {
 		k8stypes.NewStatefulSet(),
 		k8stypes.NewPodTemplate(),
 		k8stypes.NewCronJob(),
+		k8stypes.NewServiceAccount(),
 	}
 	namespaces := []string{"foo", "bar"}
 

--- a/internal/k8s/runtime.go
+++ b/internal/k8s/runtime.go
@@ -100,6 +100,8 @@ func GetObjectMeta(resource k8stypes.Resource) *metav1.ObjectMeta {
 		return &kubeType.ObjectMeta
 	case *k8stypes.NetworkPolicyV1:
 		return &kubeType.ObjectMeta
+	case *k8stypes.ServiceAccountV1:
+		return &kubeType.ObjectMeta
 	}
 
 	return nil
@@ -116,8 +118,8 @@ func GetPodObjectMeta(resource k8stypes.Resource) *metav1.ObjectMeta {
 	return GetObjectMeta(resource)
 }
 
-// GetPodSpec gets the PodSpec for a resource. Avoid using this function if you need support for Namespace resources,
-// and write a helper functions in this package instead
+// GetPodSpec gets the PodSpec for a resource. Avoid using this function if you need support for Namespace or
+// ServiceAccount resources, and write a helper functions in this package instead
 func GetPodSpec(resource k8stypes.Resource) *k8stypes.PodSpecV1 {
 	podTemplateSpec := GetPodTemplateSpec(resource)
 	if podTemplateSpec != nil {
@@ -127,7 +129,7 @@ func GetPodSpec(resource k8stypes.Resource) *k8stypes.PodSpecV1 {
 	switch kubeType := resource.(type) {
 	case *k8stypes.PodV1:
 		return &kubeType.Spec
-	case *k8stypes.NamespaceV1:
+	case *k8stypes.NamespaceV1, *k8stypes.ServiceAccountV1:
 		return nil
 	}
 
@@ -135,7 +137,7 @@ func GetPodSpec(resource k8stypes.Resource) *k8stypes.PodSpecV1 {
 }
 
 // GetPodTemplateSpec gets the PodTemplateSpec for a resource. Avoid using this function if you need support for
-// Pod or Namespace resources, and write a helper functions in this package instead
+// Pod, Namespace, or ServiceAccount resources, and write a helper functions in this package instead
 func GetPodTemplateSpec(resource k8stypes.Resource) *v1.PodTemplateSpec {
 	switch kubeType := resource.(type) {
 	case *k8stypes.CronJobV1Beta1:

--- a/k8stypes/resources.go
+++ b/k8stypes/resources.go
@@ -7,111 +7,116 @@ var podTemplateSpec = PodTemplateSpecV1{
 
 // NewDeployment creates a new Deployment resource
 func NewDeployment() *DeploymentV1 {
-	deployment := &DeploymentV1{
+	return &DeploymentV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 		Spec: DeploymentSpecV1{
 			Template: podTemplateSpec,
 		},
 	}
-
-	deployment.Kind = "Deployment"
-	deployment.APIVersion = "apps/v1"
-	return deployment
 }
 
 // NewPod creates a new Pod resource
 func NewPod() *PodV1 {
-	pod := &PodV1{
+	return &PodV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 		Spec:       PodSpecV1{},
 	}
-
-	pod.Kind = "Pod"
-	pod.APIVersion = "v1"
-	return pod
 }
 
 // NewNamespace creates a new Namespace resource
 func NewNamespace() *NamespaceV1 {
-	namespace := &NamespaceV1{
+	return &NamespaceV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 		Spec:       NamespaceSpecV1{},
 	}
-
-	namespace.Kind = "Namespace"
-	namespace.APIVersion = "v1"
-	return namespace
 }
 
 // NewDaemonSet creates a new DaemonSet resource
 func NewDaemonSet() *DaemonSetV1 {
-	daemonset := &DaemonSetV1{
+	return &DaemonSetV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "Daemonset",
+			APIVersion: "apps/v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 		Spec: DaemonSetSpecV1{
 			Template: podTemplateSpec,
 		},
 	}
-
-	daemonset.Kind = "Daemonset"
-	daemonset.APIVersion = "apps/v1"
-	return daemonset
 }
 
 // NewReplicationController creates a new ReplicationController resource
 func NewReplicationController() *ReplicationControllerV1 {
-	controller := &ReplicationControllerV1{
+	return &ReplicationControllerV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "ReplicationController",
+			APIVersion: "v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 		Spec: ReplicationControllerSpecV1{
 			Template: podTemplateSpec.DeepCopy(),
 		},
 	}
-
-	controller.Kind = "ReplicationController"
-	controller.APIVersion = "v1"
-	return controller
 }
 
 // NewStatefulSet creates a new StatefulSet resource
 func NewStatefulSet() *StatefulSetV1 {
-	controller := &StatefulSetV1{
+	return &StatefulSetV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 		Spec: StatefulSetSpecV1{
 			Template: podTemplateSpec,
 		},
 	}
-
-	controller.Kind = "StatefulSet"
-	controller.APIVersion = "apps/v1"
-	return controller
 }
 
 // NewNetworkPolicy creates a new NetworkPolicy resource
 func NewNetworkPolicy() *NetworkPolicyV1 {
-	networkPolicy := &NetworkPolicyV1{
+	return &NetworkPolicyV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "NetworkPolicy",
+			APIVersion: "networking.k8s.io/v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 		Spec:       NetworkPolicySpecV1{},
 	}
-
-	networkPolicy.Kind = "NetworkPolicy"
-	networkPolicy.APIVersion = "networking.k8s.io/v1"
-	return networkPolicy
 }
 
 // NewPodTemplate creates a new PodTemplate resource
 func NewPodTemplate() *PodTemplateV1 {
-	podTemplate := &PodTemplateV1{
+	return &PodTemplateV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "PodTemplate",
+			APIVersion: "v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 		Template:   podTemplateSpec,
 	}
-
-	podTemplate.Kind = "PodTemplate"
-	podTemplate.APIVersion = "v1"
-	return podTemplate
 }
 
 // NewCronJob creates a new CronJob resource
 func NewCronJob() *CronJobV1Beta1 {
-	cronJob := &CronJobV1Beta1{
+	return &CronJobV1Beta1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "CronJob",
+			APIVersion: "batch/v1beta1",
+		},
+		ObjectMeta: ObjectMetaV1{},
 		Spec: CronJobSpecV1Beta1{
 			JobTemplate: JobTemplateSpecV1Beta1{
 				Spec: JobSpecV1{
@@ -120,19 +125,15 @@ func NewCronJob() *CronJobV1Beta1 {
 			},
 		},
 	}
-
-	cronJob.Kind = "CronJob"
-	cronJob.APIVersion = "batch/v1beta1"
-	return cronJob
 }
 
 // NewServiceAccount creates a new ServiceAccount resource
 func NewServiceAccount() *ServiceAccountV1 {
-	serviceAccount := &ServiceAccountV1{
+	return &ServiceAccountV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
 		ObjectMeta: ObjectMetaV1{},
 	}
-
-	serviceAccount.Kind = "ServiceAccount"
-	serviceAccount.APIVersion = "v1"
-	return serviceAccount
 }

--- a/k8stypes/resources.go
+++ b/k8stypes/resources.go
@@ -125,3 +125,14 @@ func NewCronJob() *CronJobV1Beta1 {
 	cronJob.APIVersion = "batch/v1beta1"
 	return cronJob
 }
+
+// NewServiceAccount creates a new ServiceAccount resource
+func NewServiceAccount() *ServiceAccountV1 {
+	serviceAccount := &ServiceAccountV1{
+		ObjectMeta: ObjectMetaV1{},
+	}
+
+	serviceAccount.Kind = "ServiceAccount"
+	serviceAccount.APIVersion = "v1"
+	return serviceAccount
+}

--- a/k8stypes/type_checks.go
+++ b/k8stypes/type_checks.go
@@ -4,13 +4,3 @@ func IsNamespaceV1(resource Resource) bool {
 	_, ok := resource.(*NamespaceV1)
 	return ok
 }
-
-func IsNetworkPolicyV1(resource Resource) bool {
-	_, ok := resource.(*NetworkPolicyV1)
-	return ok
-}
-
-func IsServiceAccountV1(resource Resource) bool {
-	_, ok := resource.(*ServiceAccountV1)
-	return ok
-}

--- a/k8stypes/type_checks.go
+++ b/k8stypes/type_checks.go
@@ -1,0 +1,16 @@
+package k8stypes
+
+func IsNamespaceV1(resource Resource) bool {
+	_, ok := resource.(*NamespaceV1)
+	return ok
+}
+
+func IsNetworkPolicyV1(resource Resource) bool {
+	_, ok := resource.(*NetworkPolicyV1)
+	return ok
+}
+
+func IsServiceAccountV1(resource Resource) bool {
+	_, ok := resource.(*ServiceAccountV1)
+	return ok
+}

--- a/k8stypes/types.go
+++ b/k8stypes/types.go
@@ -22,17 +22,11 @@ type CapabilityV1 = apiv1.Capability
 // ContainerV1 is a type alias for the v1 version of the k8s API.
 type ContainerV1 = apiv1.Container
 
-// CronJobListV1Beta1 is a type alias for the v1beta1 version of the k8s batch API.
-type CronJobListV1Beta1 = batchv1beta1.CronJobList
-
 // CronJobV1Beta1 is a type alias for the v1beta1 version of the k8s batch API.
 type CronJobV1Beta1 = batchv1beta1.CronJob
 
 // CronJobSpecV1Beta1 is a type alias for the v1beta1 version of the k8s batch API.
 type CronJobSpecV1Beta1 = batchv1beta1.CronJobSpec
-
-// DaemonSetListV1 is a type alias for the v1 version of the k8s apps API.
-type DaemonSetListV1 = appsv1.DaemonSetList
 
 // DaemonSetSpecV1 is a type alias for the v1 version of the k8s apps API.
 type DaemonSetSpecV1 = appsv1.DaemonSetSpec
@@ -48,9 +42,6 @@ type DaemonSetV1Beta2 = appsv1beta2.DaemonSet
 
 // DeploymentExtensionsV1Beta1 is a type alias for the v1beta1 version of the k8s extensions API.
 type DeploymentExtensionsV1Beta1 = extensionsv1beta1.Deployment
-
-// DeploymentListV1 is a type alias for the v1 version of the k8s apps API.
-type DeploymentListV1 = appsv1.DeploymentList
 
 // DeploymentSpecV1 is a type alias for the v1 version of the k8s apps API.
 type DeploymentSpecV1 = appsv1.DeploymentSpec
@@ -79,12 +70,6 @@ type NamespaceV1 = apiv1.Namespace
 // NamespaceSpecV1 is a type alias for the v1 version of the k8s API.
 type NamespaceSpecV1 = apiv1.NamespaceSpec
 
-// NamespaceListV1 is a type alias for the v1 version of the k8s API.
-type NamespaceListV1 = apiv1.NamespaceList
-
-// NetworkPolicyListV1 is a type alias for the v1 version of the k8s networking API.
-type NetworkPolicyListV1 = networkingv1.NetworkPolicyList
-
 // NetworkPolicySpecV1 is a type alias for the v1 version of the k8s networking API.
 type NetworkPolicySpecV1 = networkingv1.NetworkPolicySpec
 
@@ -94,17 +79,11 @@ type NetworkPolicyV1 = networkingv1.NetworkPolicy
 // ObjectMetaV1 is a type alias for the v1 version of the k8s meta API.
 type ObjectMetaV1 = metav1.ObjectMeta
 
-// PodListV1 is a type alias for the v1 version of the k8s API.
-type PodListV1 = apiv1.PodList
-
 // PodSpecV1 is a type alias for the v1 version of the k8s API.
 type PodSpecV1 = apiv1.PodSpec
 
 // PodTemplateSpecV1 is a type alias for the v1 version of the k8s API.
 type PodTemplateSpecV1 = apiv1.PodTemplateSpec
-
-// PodTemplateListV1 is a type alias for the v1 version of the k8s API.
-type PodTemplateListV1 = apiv1.PodTemplateList
 
 // PodTemplateV1 is a type alias for the v1 version of the k8s API.
 type PodTemplateV1 = apiv1.PodTemplate
@@ -114,9 +93,6 @@ type PodV1 = apiv1.Pod
 
 // PolicyTypeV1 is a type alias for the v1 version of the k8s networking API.
 type PolicyTypeV1 = networkingv1.PolicyType
-
-// ReplicationControllerListV1 is a type alias for the v1 version of the k8s API.
-type ReplicationControllerListV1 = apiv1.ReplicationControllerList
 
 // ReplicationControllerSpecV1 is a type alias for the v1 version of the k8s API.
 type ReplicationControllerSpecV1 = apiv1.ReplicationControllerSpec
@@ -130,14 +106,8 @@ type Resource k8sRuntime.Object
 // SecurityContextV1 is a type alias for the v1 version of the k8s API.
 type SecurityContextV1 = apiv1.SecurityContext
 
-// ServiceAccountListV1 is a type alias for the v1 version of the k8s API.
-type ServiceAccountListV1 = apiv1.ServiceAccountList
-
 // ServiceAccountV1 is a type alias for the v1 version of the k8s API.
 type ServiceAccountV1 = apiv1.ServiceAccount
-
-// StatefulSetListV1 is a type alias for the v1 version of the k8s apps API.
-type StatefulSetListV1 = appsv1.StatefulSetList
 
 // StatefulSetSpecV1 is a type alias for the v1 version of the k8s apps API.
 type StatefulSetSpecV1 = appsv1.StatefulSetSpec

--- a/k8stypes/types.go
+++ b/k8stypes/types.go
@@ -130,6 +130,12 @@ type Resource k8sRuntime.Object
 // SecurityContextV1 is a type alias for the v1 version of the k8s API.
 type SecurityContextV1 = apiv1.SecurityContext
 
+// ServiceAccountListV1 is a type alias for the v1 version of the k8s API.
+type ServiceAccountListV1 = apiv1.ServiceAccountList
+
+// ServiceAccountV1 is a type alias for the v1 version of the k8s API.
+type ServiceAccountV1 = apiv1.ServiceAccount
+
 // StatefulSetListV1 is a type alias for the v1 version of the k8s apps API.
 type StatefulSetListV1 = appsv1.StatefulSetList
 
@@ -156,6 +162,7 @@ func IsSupportedResourceType(obj Resource) bool {
 		*PodV1,
 		*PodTemplateV1,
 		*ReplicationControllerV1,
+		*ServiceAccountV1,
 		*StatefulSetV1, *StatefulSetV1Beta1:
 		return true
 	default:

--- a/k8stypes/types.go
+++ b/k8stypes/types.go
@@ -118,6 +118,9 @@ type StatefulSetV1 = appsv1.StatefulSet
 // StatefulSetV1Beta1 is a type alias for the v1beta1 version of the k8s API.
 type StatefulSetV1Beta1 = appsv1beta1.StatefulSet
 
+// TypeMetaV1 is a type alias for the v1 version of the k8s meta API.
+type TypeMetaV1 = metav1.TypeMeta
+
 // UnsupportedType is a type alias for v1 version of the k8s apps API, this is meant for testing
 type UnsupportedType = apiv1.Binding
 


### PR DESCRIPTION
##### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Makes it so the `asat` auditor won't complain that token automounting is enabled if `automountServiceAccountToken: false` is set on the default ServiceAccount (and `automountServiceAccountToken` is not set to `true` in the PodSpec).

Fixes #290 

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] If the default service account has `automountServiceAccountToken: false` and the PodSpec does not have `automountServiceAccountToken: true` => no error
- [x] In manifest mode, if the default service account is being automounted and we know about the default service account, autofix adds `automountServiceAccountToken: true` to the default service account, otherwise on the PodSpec

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
