### PR TITLE
Update docs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,19 +5,13 @@ release:
     name: kubeaudit
   draft: true
   name_template: "{{.ProjectName}}-v{{.Version}}"
-brews:
-- github:
-    owner: Shopify
-    name: homebrew-shopify
-  install: bin.install "kubeaudit"
-  homepage: "https://github.com/Shopify/kubeaudit"
-  description: "kubeaudit audits Kubernetes clusters for common security controls"
 dockers:
 - dockerfile: goreleaser.Dockerfile
   image_templates:
   - "shopify/kubeaudit:latest"
   - "shopify/kubeaudit:{{ .Tag }}"
   - "shopify/kubeaudit:v{{ .Major }}"
+  - "shopify/kubeaudit:v{{ .Major }}.{{ .Minor }}"
 builds:
 - goos:
   - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,9 @@ release:
   name_template: "{{.ProjectName}}-v{{.Version}}"
 dockers:
 - dockerfile: goreleaser.Dockerfile
+  goos: linux
+  goarch: amd64
+  goarm: ''
   image_templates:
   - "shopify/kubeaudit:latest"
   - "shopify/kubeaudit:{{ .Tag }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder --chown=app /go/bin/kubeaudit /kubeaudit
 
 # from now on, run as the unprivileged user
-USER app
+USER 1000
 
 # entrypoint
 ENTRYPOINT ["/kubeaudit"]

--- a/README.md
+++ b/README.md
@@ -144,22 +144,21 @@ To write the fixed manifest to a new file instead of modifying the source file, 
 kubeaudit autofix -f "/path/to/manifest.yml" -o "/path/to/fixed"
 ```
 
-### Local Mode
-
-If a kubeconfig file is provided using the `-c/--kubeconfig` flag, kubeaudit will audit the resources specified in the kubeconfig file. If no kubeconfig file is specified, `$HOME/.kube/config` is used by default:
-
-```
-kubeaudit all -c "/path/to/config"
-```
-
-For more information on kubernetes config files, see https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-
 ### Cluster Mode
 
 Kubeaudit can detect if it is running within a container in a cluster. If so, it will try to audit all Kubernetes resources in that cluster:
 ```
 kubeaudit all
 ```
+
+### Local Mode
+
+Kubeaudit will try to connect to a cluster using the local kubeconfig file (`$HOME/.kube/config`). A different kubeconfig location can be specified using the `-c/--kubeconfig` flag.
+```
+kubeaudit all -c "/path/to/config"
+```
+
+For more information on kubernetes config files, see https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 
 ## Audit Results
 
@@ -171,7 +170,7 @@ Kubeaudit produces results with three levels of severity:
 
 The minimum severity level can be set using the `--minSeverity/-m` flag.
 
-By default kubeaudit will output results in a human-readable way. If the output is intended to be further processed, it can be set to output JSON using the `--format json` flag.
+By default kubeaudit will output results in a human-readable way. If the output is intended to be further processed, it can be set to output JSON using the `--format json` flag. To output results as logs (the previous default) use `--format logrus`.
 
 If there are results of severity level `error`, kubeaudit will exit with exit code 2. This can be changed using the `--exitcode/-e` flag.
 
@@ -213,7 +212,7 @@ Auditors can also be run individually.
 | -f      | --manifest     | Path to the yaml configuration to audit. Only used in manifest mode.                                |
 | -n      | --namespace    | Only audit resources in the specified namespace. Not currently supported in manifest mode.          |
 | -m      | --minseverity  | Set the lowest severity level to report (one of "error", "warning", "info") (default "info")        |
-| -e      | --exitcode     | Exit code to use if there are results with severity of "error". Conventionally, 0 is used for succes and all non-zero codes for an error. (default 2) |
+| -e      | --exitcode     | Exit code to use if there are results with severity of "error". Conventionally, 0 is used for success and all non-zero codes for an error. (default 2) |
 
 ## Configuration File
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,15 @@ The rest of this README will focus on how to use kubeaudit as a command line too
 * [Commands](#commands)
 * [Configuration File](#configuration-file)
 * [Override Errors](#override-errors)
-* [CI/CD Usage](#cicd-usage)
 * [Contributing](#contributing)
 
 ## Installation
+
+### Brew
+
+```
+brew install kubeaudit
+```
  
 ### Download a binary
 
@@ -72,6 +77,10 @@ With kubectl v1.12.0 introducing [easy pluggability](https://kubernetes.io/docs/
 or
 
 - renaming the binary to `kubectl-audit` and having it available in your path.
+
+### Docker
+
+We also release a [Docker image](https://hub.docker.com/r/shopify/kubeaudit): `shopify/kubeaudit`. To run kubeaudit as a job in your cluster see [Running kubeaudit in a cluster](docs/cluster.md).
 
 ## Quick Start
 
@@ -160,7 +169,13 @@ Kubeaudit produces results with three levels of severity:
 `Warning`: A best practice recommendation
 `Info`: Informational, no action required. This includes results that are [overridden](#override-errors)
 
-The minimum severity level can be set using the `--minSeverity/-m` flag. See [Global Flags](#global-flags) for a more detailed description.
+The minimum severity level can be set using the `--minSeverity/-m` flag.
+
+By default kubeaudit will output results in a human-readable way. If the output is intended to be further processed, it can be set to output JSON using the `--format json` flag.
+
+If there are results of severity level `error`, kubeaudit will exit with exit code 2. This can be changed using the `--exitcode/-e` flag.
+
+For all the ways kubeaudit can be customized, see [Global Flags](#global-flags).
 
 ## Commands
 
@@ -196,8 +211,9 @@ Auditors can also be run individually.
 |         | --format       | The output format to use (one of "pretty", "logrus", "json") (default is "pretty")                  |
 | -c      | --kubeconfig   | Path to local Kubernetes config file. Only used in local mode (default is `$HOME/.kube/config`)     |
 | -f      | --manifest     | Path to the yaml configuration to audit. Only used in manifest mode.                                |
-| -n      | --namespace    | Only audit resources in the specified namespace. Not currently supported in manifest mode.                         |
-| -m      | --minseverity  | Set the lowest severity level to report (one of "error", "warning", "info") (default "info")           |
+| -n      | --namespace    | Only audit resources in the specified namespace. Not currently supported in manifest mode.          |
+| -m      | --minseverity  | Set the lowest severity level to report (one of "error", "warning", "info") (default "info")        |
+| -e      | --exitcode     | Exit code to use if there are results with severity of "error". Conventionally, 0 is used for succes and all non-zero codes for an error. (default 2) |
 
 ## Configuration File
 
@@ -247,11 +263,6 @@ Multiple override labels (for multiple auditors) can be added to the same resour
 See the specific [auditor docs](#auditors) for the auditor you wish to override for examples.
 
 To learn more about labels, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-
-## CI/CD usage
-
-kubeaudit will return exit code `2` whenever any errors are being found, so it can stop your pipeline.
-If you do not want this to happen, run it as `kubeaudit all || true`
 
 ## Contributing
 

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -22,21 +22,19 @@ type rootFlags struct {
 	manifest    string
 	namespace   string
 	minSeverity string
+	exitCode    int
 }
 
 // RootCmd defines the shell command usage for kubeaudit.
 var RootCmd = &cobra.Command{
 	Use:   "kubeaudit",
 	Short: "A Kubernetes security auditor",
-	Long: `kubeaudit is a program that makes sure all your containers are secure #patcheswelcome
+	Long: `Kubeaudit audits Kubernetes clusters for common security controls.
 
 kubeaudit has three modes:
-1. Manifest mode: If a Kubernetes manifest file is provided using the -f/--manifest flag, kubeaudit will audit the manifest file.
-	 Kubeaudit also supports autofixing in manifest mode using the 'autofix' command. This will fix the manifest in-place.
-	 The fixed manfiest can be written to a different file using the -o/--out flag.
-2. Cluster mode: If kubeaudit detects it is running within a container, it will try to audit the cluster it is contained in.
-3. Local mode: kubeaudit will audit the resources specified by the local kubeconfig file ($HOME/.kube/config). A different
-     kubeaconfig location can be specified using the -c/--kubeconfig flag
+  1. Manifest mode: If a Kubernetes manifest file is provided using the -f/--manifest flag, kubeaudit will audit the manifest file. Kubeaudit also supports autofixing in manifest mode using the 'autofix' command. This will fix the manifest in-place. The fixed manfiest can be written to a different file using the -o/--out flag.
+  2. Cluster mode: If kubeaudit detects it is running within a container, it will try to audit the cluster it is contained in.
+  3. Local mode: kubeaudit will audit the resources specified by the local kubeconfig file ($HOME/.kube/config). A different kubeaconfig location can be specified using the -c/--kubeconfig flag
 `,
 }
 
@@ -53,6 +51,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.format, "format", "p", "pretty", "The output format to use (one of \"pretty\", \"logrus\", \"json\")")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.namespace, "namespace", "n", apiv1.NamespaceAll, "Only audit resources in the specified namespace. Not currently supported in manifest mode.")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.manifest, "manifest", "f", "", "Path to the yaml configuration to audit. Only used in manifest mode.")
+	RootCmd.PersistentFlags().IntVarP(&rootConfig.exitCode, "exitcode", "e", 2, "Exit code to use if there are results with severity of \"error\". Conventionally, 0 is used for succes and all non-zero codes for an error.")
 }
 
 // KubeauditLogLevels represents an enum for the supported log levels.
@@ -81,7 +80,7 @@ func runAudit(auditable ...kubeaudit.Auditable) func(cmd *cobra.Command, args []
 		report.PrintResults(printOptions...)
 
 		if report.HasErrors() {
-			os.Exit(2)
+			os.Exit(rootConfig.exitCode)
 		}
 	}
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -32,9 +32,9 @@ var RootCmd = &cobra.Command{
 	Long: `Kubeaudit audits Kubernetes clusters for common security controls.
 
 kubeaudit has three modes:
-  1. Manifest mode: If a Kubernetes manifest file is provided using the -f/--manifest flag, kubeaudit will audit the manifest file. Kubeaudit also supports autofixing in manifest mode using the 'autofix' command. This will fix the manifest in-place. The fixed manfiest can be written to a different file using the -o/--out flag.
-  2. Cluster mode: If kubeaudit detects it is running within a container, it will try to audit the cluster it is contained in.
-  3. Local mode: kubeaudit will audit the resources specified by the local kubeconfig file ($HOME/.kube/config). A different kubeaconfig location can be specified using the -c/--kubeconfig flag
+  1. Manifest mode: If a Kubernetes manifest file is provided using the -f/--manifest flag, kubeaudit will audit the manifest file. Kubeaudit also supports autofixing in manifest mode using the 'autofix' command. This will fix the manifest in-place. The fixed manifest can be written to a different file using the -o/--out flag.
+  2. Cluster mode: If kubeaudit detects it is running in a cluster, it will audit the other resources in the cluster.
+  3. Local mode: kubeaudit will try to connect to a cluster using the local kubeconfig file ($HOME/.kube/config). A different kubeconfig location can be specified using the -c/--kubeconfig flag
 `,
 }
 
@@ -51,7 +51,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.format, "format", "p", "pretty", "The output format to use (one of \"pretty\", \"logrus\", \"json\")")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.namespace, "namespace", "n", apiv1.NamespaceAll, "Only audit resources in the specified namespace. Not currently supported in manifest mode.")
 	RootCmd.PersistentFlags().StringVarP(&rootConfig.manifest, "manifest", "f", "", "Path to the yaml configuration to audit. Only used in manifest mode.")
-	RootCmd.PersistentFlags().IntVarP(&rootConfig.exitCode, "exitcode", "e", 2, "Exit code to use if there are results with severity of \"error\". Conventionally, 0 is used for succes and all non-zero codes for an error.")
+	RootCmd.PersistentFlags().IntVarP(&rootConfig.exitCode, "exitcode", "e", 2, "Exit code to use if there are results with severity of \"error\". Conventionally, 0 is used for success and all non-zero codes for an error.")
 }
 
 // KubeauditLogLevels represents an enum for the supported log levels.

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -1,0 +1,254 @@
+# Running kubeaudit in a Cluster
+
+Kubeaudit can be run in a Kubernetes cluster by using the [official Docker image](https://hub.docker.com/r/shopify/kubeaudit): `shopify/kubeaudit`.
+
+## Without RBAC
+
+Example Job configuration:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubeaudit
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/kubeaudit: runtime/default
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+    spec:
+      automountServiceAccount: false
+      containers:
+        - name: kubeaudit
+          image: shopify/kubeaudit:v0.11
+          args: ["all", "--exitcode", "0"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["all"]
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+```
+
+## With RBAC
+
+If RBAC is enabled on the cluster:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeaudit
+  namespace: default
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubeaudit
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - podtemplates
+      - replicationcontrollers
+      - namespaces
+      - serviceaccounts
+    verbs: ["list"]
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - statefulsets
+      - deployments
+    verbs: ["list"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+    verbs: ["list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs: ["list"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubeaudit
+subjects:
+  - kind: ServiceAccount
+    name: kubeaudit
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeaudit
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubeaudit
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/kubeaudit: runtime/default
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+    spec:
+      serviceAccountName: kubeaudit
+      containers:
+        - name: kubeaudit
+          image: shopify/kubeaudit:v0.11
+          args: ["all", "--exitcode", "0"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["all"]
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+```
+
+## With RBAC and a Specific Namespace
+
+If you are running kubeaudit on a specific namespace and don't want to grant it cluster wide access, the binding can be made into a namespaced binding, but note that kubeaudit will still need to be able to list namespaces at the cluster level (as namespace resources don't have a namespaced scope).
+
+In the following example, the `kubeaudit` Job is created in the `kubeaudit` namespace and is assigned a ServiceAccount which can list namespaces at a cluster scope but can only list the other resources for the provided namespace.
+
+**Important**: Replace the two instances of `<TARGET_NAMESPACE>` with the namespace you want kubeaudit to audit:
+
+```yaml
+# Optionally, run kubeaudit in its own namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeaudit
+
+---
+
+# Don't allow internet traffic in or out of the kubeaudit namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: kubeaudit
+spec:
+  policyTypes:
+  - Ingress
+  - Egress
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeaudit
+  namespace: kubeaudit
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubeaudit-namespaces
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["list"]
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubeaudit
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - podtemplates
+      - replicationcontrollers
+      - serviceaccounts
+    verbs: ["list"]
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+      - statefulsets
+      - deployments
+    verbs: ["list"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+    verbs: ["list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs: ["list"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubeaudit-namespaces
+subjects:
+  - kind: ServiceAccount
+    name: kubeaudit
+    namespace: kubeaudit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeaudit-namespaces
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubeaudit
+  namespace: <TARGET_NAMESPACE>
+subjects:
+  - kind: ServiceAccount
+    name: kubeaudit
+    namespace: kubeaudit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeaudit
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubeaudit
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/kubeaudit: runtime/default
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+    spec:
+      serviceAccountName: kubeaudit
+      containers:
+        - name: kubeaudit
+          image: shopify/kubeaudit:v0.11
+          args: ["all", "--exitcode", "0", "--namespace", "<TARGET_NAMESPACE>"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["all"]
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+```

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -20,6 +20,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
     spec:
       automountServiceAccount: false
+      restartPolicy: OnFailure
       containers:
         - name: kubeaudit
           image: shopify/kubeaudit:v0.11
@@ -104,6 +105,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
     spec:
       serviceAccountName: kubeaudit
+      restartPolicy: OnFailure
       containers:
         - name: kubeaudit
           image: shopify/kubeaudit:v0.11
@@ -240,6 +242,7 @@ spec:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
     spec:
       serviceAccountName: kubeaudit
+      restartPolicy: OnFailure
       containers:
         - name: kubeaudit
           image: shopify/kubeaudit:v0.11

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEg
 github.com/Azure/go-autorest/autorest/date v0.1.0 h1:YGrhWfrgtFs84+h0o46rJrlmsZtyZRg470CqAXTZaGM=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/autorest/mocks v0.2.0 h1:Ww5g4zThfD/6cLb4z6xxgeyDa7QDkizMkJKe0ysZXp0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/to v0.3.0/go.mod h1:MgwOyqaIuKdG4TL/2ywSsIWKAfJfgHDo8ObuUk3t5sA=
 github.com/Azure/go-autorest/autorest/validation v0.2.0/go.mod h1:3EEqHnBxQGHXRYq3HT1WyXAvT7LLY3tl70hw6tQIbjI=

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -1,6 +1,39 @@
+FROM golang:1.15.1 AS builder
+
+# no need to include cgo bindings
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+
+# add ca certificates and timezone data files
+# hadolint ignore=DL3008
+RUN apt-get install --yes --no-install-recommends ca-certificates tzdata
+
+# add unprivileged user
+RUN adduser --shell /bin/true --uid 1000 --disabled-login --no-create-home --gecos '' app \
+  && sed -i -r "/^(app|root)/!d" /etc/group /etc/passwd \
+  && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
+
+#
+# ---
+#
+
+# start with empty image
 FROM scratch
 
+# add-in our timezone data file
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# add-in our unprivileged user
+COPY --from=builder /etc/passwd /etc/group /etc/shadow /etc/
+
+# add-in our ca certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# add-in our application
 COPY kubeaudit /
 
+# from now on, run as the unprivileged user
+USER app
+
+# entrypoint
 ENTRYPOINT ["/kubeaudit"]
 CMD ["all"]

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -32,7 +32,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY kubeaudit /
 
 # from now on, run as the unprivileged user
-USER app
+USER 1000
 
 # entrypoint
 ENTRYPOINT ["/kubeaudit"]


### PR DESCRIPTION
##### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Adds instructions on how to use the official Docker image to run kubeaudit in a cluster. I also had to add a flag to set the exit code to 0 (the "success" code) otherwise Kubernetes will think the Job failed.

Fixes #277 

##### Type of change

<!-- Please delete options that are not relevant. --->
- [ ] Bug fix :bug:
- [ ] New feature :sparkles:
- [x] This change requires a documentation update :book:
- [ ] Breaking changes :warning:

##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] `make test-setup`
         Applied the kubernetes resources (for ["With RBAC"](https://github.com/Shopify/kubeaudit/blob/update-docs/docs/cluster.md#with-rbac)) with the currently live docker image `shopify/kubeaudit` and made sure the Job ran (currently the Pod created by the Job will have status `Error` because the flag to change the exit code isn't live yet)
- [x] `go run cmd/main.go apparmor -f internal/test/fixtures/all_resources/daemonset-v1beta1.yml -e 0`

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
