### PR TITLE
Run Auditlocal, even when kubeaudit detected to run in a cluster.

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -100,7 +100,7 @@ func getReport(auditors ...kubeaudit.Auditable) *kubeaudit.Report {
 		return report
 	}
 
-	if k8s.IsRunningInCluster(k8s.DefaultClient) {
+	if ( k8s.IsRunningInCluster(k8s.DefaultClient) && rootConfig.kubeConfig == "" ) {
 		report, err := auditor.AuditCluster(k8s.ClientOptions{Namespace: rootConfig.namespace})
 		if err != nil {
 			log.WithError(err).Fatal("Error auditing cluster")


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description
Allows to run kubeaudit inside a cluster when a kubectl configuration is passed. 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #303 

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
- [x] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?
I run it on my cluster with `.kubectl all -c /path/to/my/kubectl.conf`

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
<!--
- [ ] Test A
- [ ] Test B
 -->
##### Checklist:

- [ ] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
