### PR TITLE
writes only to file and truncate it, so overwrite works as expected

### DIFF
--- a/cmd/commands/autofix.go
+++ b/cmd/commands/autofix.go
@@ -23,7 +23,7 @@ func autofix(cmd *cobra.Command, args []string) {
 			log.WithError(err).Fatal("Error opening out file")
 		}
 	} else {
-		f, err = os.OpenFile(rootConfig.manifest, os.O_RDWR, 0755)
+		f, err = os.OpenFile(rootConfig.manifest, os.O_WRONLY|os.O_TRUNC, 0755)
 		if err != nil {
 			log.WithError(err).Fatal("Error opening manifest file")
 		}


### PR DESCRIPTION
##### Description

Fixes  #306 

Autofix was not overwriting the file as expected. The effective result is that we clear the file first before writing to it, rather than just overwriting, because there could be bits of the original file remaining at the end.

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

##### Checklist:

- [ ] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [ ] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
