### PR TITLE
reports 0 vulnerabilies in case the check is successful

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ $ kubeaudit all -f "internal/test/fixtures/all_resources/deployment-apps-v1.yml"
 ...
 ```
 
+If no errors with a given minimum severity are found, the following is returned:
+
+```shell
+All checks completed. 0 high-risk vulnerabilities found
+```
+
 #### Autofix
 
 Manifest mode also supports autofixing all security issues using the `autofix` command:

--- a/printer.go
+++ b/printer.go
@@ -65,6 +65,10 @@ func (p *Printer) PrintReport(report *Report) {
 }
 
 func (p *Printer) prettyPrintReport(report *Report) {
+	if len(report.ResultsWithMinSeverity(p.minSeverity)) < 1 {
+		p.printColor(color.GreenColor, "All checks completed. 0 high-risk vulnerabilities found\n")
+	}
+
 	for _, workloadResult := range report.ResultsWithMinSeverity(p.minSeverity) {
 		resource := workloadResult.GetResource().Object()
 		objectMeta := k8s.GetObjectMeta(resource)


### PR DESCRIPTION
##### Description

Closes https://github.com/Shopify/kubeaudit/issues/311

After running `kubeaudit` and not having found errors with a given minimum severity to be reported, a message is printed to the cli in order to let the user know that no high-risk vulnerabilities were found.

<img width="676" alt="Screen Shot 2020-10-15 at 7 15 01 PM" src="https://user-images.githubusercontent.com/22174780/96195438-c5fa1780-0f1a-11eb-828c-fb4b60d3ee81.png">

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Enhancement / UX improvement

##### How Has This Been Tested?
- [x] Manual test

I'm running `kubeaudit all -k config.yaml -f manifest.yaml` 

I'm using these files:
`manifest.yaml`
```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: deployment
spec:
  selector:
    matchLabels:
      name: deployment
  template:
    metadata:
      labels:
        name: deployment
      annotations:
        container.apparmor.security.beta.kubernetes.io/container: runtime/default
        seccomp.security.alpha.kubernetes.io/pod: runtime/default
    spec:
      containers:
        - name: container
          image: scratch
```

`config.yaml`:

```yaml
enabledAuditors:
  apparmor: true
  asat: true
  capabilities: false
  hostns: true
  image: true
  limits: true
  mountds: true
  netpols: true
  nonroot: false
  privesc: true
  privileged: false
  rootfs: true
  seccomp: true
auditors:
  capabilities:
    drop:
      - AUDIT_WRITE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETPCAP
      - SYS_CHROOT
```
This gives me the following report: 
```shell

---------------- Results for ---------------

  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: deployment

--------------------------------------------

-- [error] AutomountServiceAccountTokenTrueAndDefaultSA
   Message: Default service account with token mounted. automountServiceAccountToken should be set to 'false' on either the ServiceAccount or on the PodSpec or a non-default service account should be used.

-- [warning] LimitsNotSet
   Message: Resource limits not set.
   Metadata:
      Container: container

-- [warning] ImageTagMissing
   Message: Image tag is missing.
   Metadata:
      Container: container

-- [error] AllowPrivilegeEscalationNil
   Message: allowPrivilegeEscalation not set which allows privilege escalation. It should be set to 'false'.
   Metadata:
      Container: container

-- [error] ReadOnlyRootFilesystemNil
   Message: readOnlyRootFilesystem is not set in container SecurityContext. It should be set to 'true'.
   Metadata:
      Container: container
````
Little by little, I changed the config to disable some auditors, like:
```yaml
enabledAuditors:
  apparmor: true
  asat: false
  capabilities: false
  hostns: true
  image: false
  limits: false
  mountds: true
  netpols: true
  nonroot: false
  privesc: false
  privileged: false
  rootfs: false
  seccomp: false
auditors:
  capabilities:
    drop:
      - AUDIT_WRITE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETPCAP
      - SYS_CHROOT
```

which returned:

```shell
All checks completed. 0 high-risk vulnerabilities found
```

Another kind of test was running `kubeaudit all autofix -f manifest.yaml` 

And then running `all -k ~/Desktop/kubeaudit-config.yml -f ~/Desktop/manifest.yamlt` again with the following config (which disables `image` and `limits`):

```yaml
enabledAuditors:
  apparmor: true
  asat: false
  capabilities: false
  hostns: true
  image: false
  limits: false
  mountds: true
  netpols: true
  nonroot: false
  privesc: true
  privileged: false
  rootfs: false
  seccomp: false
auditors:
  capabilities:
    drop:
      - AUDIT_WRITE
      - FOWNER
      - FSETID
      - KILL
      - MKNOD
      - NET_BIND_SERVICE
      - NET_RAW
      - SETFCAP
      - SETPCAP
      - SYS_CHROOT
```

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
- [ ] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
