### PR TITLE
Deprecate mountds command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ before_script:
   # Download and install kubectl
   - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   
-  # Download and install KinD
+  # Download and install Kind
   - GO111MODULE=on go get sigs.k8s.io/kind
-  # It's possible to download and install KinD using curl, similar as for kubectl
+  # It's possible to download and install Kind using curl, similar as for kubectl
   # This is useful in cases when Go toolchain isn't available or you prefer running stable version
-  # Binaries for KinD are available on GitHub Releases: https://github.com/kubernetes-sigs/kind/releases
+  # Binaries for Kind are available on GitHub Releases: https://github.com/kubernetes-sigs/kind/releases
   # - curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/0.0.1/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
 
 script:

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Auditors can also be run individually.
 | `hostns`       | Finds containers that have HostPID, HostIPC or HostNetwork enabled.                                            | [docs](docs/auditors/hostns.md)       |
 | `image`        | Finds containers which do not use the desired version of an image (via the tag) or use an image without a tag. | [docs](docs/auditors/image.md)        |
 | `limits`       | Finds containers which exceed the specified CPU and memory limits or do not specify any.                       | [docs](docs/auditors/limits.md)       |
-| `mountds`      | Finds containers that have docker socket mounted.                                                              | [docs](docs/auditors/mountds.md)      |
+| `mountds`      | DEPRECATED. Use `mounts` instead.                                                                              | [docs](docs/auditors/mountds.md)      |
 | `mounts`       | Finds containers that have sensitive host paths mounted.                                                       | [docs](docs/auditors/mountds.md)      |
 | `netpols`      | Finds namespaces that do not have a default-deny network policy.                                               | [docs](docs/auditors/netpols.md)      |
 | `nonroot`      | Finds containers running as root.                                                                              | [docs](docs/auditors/nonroot.md)      |
@@ -247,7 +247,7 @@ enabledAuditors:
   hostns: true
   image: true
   limits: true
-  mountds: true
+  mounts: true
   netpols: true
   nonroot: true
   privesc: true

--- a/auditors/all/all.go
+++ b/auditors/all/all.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Shopify/kubeaudit/auditors/hostns"
 	"github.com/Shopify/kubeaudit/auditors/image"
 	"github.com/Shopify/kubeaudit/auditors/limits"
-	"github.com/Shopify/kubeaudit/auditors/mountds"
 	"github.com/Shopify/kubeaudit/auditors/mounts"
 	"github.com/Shopify/kubeaudit/auditors/netpols"
 	"github.com/Shopify/kubeaudit/auditors/nonroot"
@@ -32,7 +31,6 @@ var AuditorNames = []string{
 	image.Name,
 	limits.Name,
 	mounts.Name,
-	mountds.Name,
 	netpols.Name,
 	nonroot.Name,
 	privesc.Name,
@@ -75,8 +73,6 @@ func initAuditor(name string, conf config.KubeauditConfig) (kubeaudit.Auditable,
 		return limits.New(conf.GetAuditorConfigs().Limits)
 	case mounts.Name:
 		return mounts.New(conf.GetAuditorConfigs().Mounts), nil
-	case mountds.Name:
-		return mountds.New(), nil
 	case netpols.Name:
 		return netpols.New(), nil
 	case nonroot.Name:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,7 +8,6 @@ enabledAuditors:
     hostns: true
     image: true
     limits: true
-    mountds: true
     mounts: true
     netpols: true
     nonroot: true

--- a/docs/auditors/mountds.md
+++ b/docs/auditors/mountds.md
@@ -1,5 +1,7 @@
 # Docker Socket Mounted Auditor (mountds)
 
+DEPRECATED. Please use `mounts` instead. This command will be removed in a future minor version.
+
 Finds containers that have the docker socket mounted.
 
 ## General Usage

--- a/printer.go
+++ b/printer.go
@@ -65,8 +65,11 @@ func (p *Printer) PrintReport(report *Report) {
 }
 
 func (p *Printer) prettyPrintReport(report *Report) {
+	p.printColor(color.RedColor, "\nDEPRECATION NOTICE: The 'mountds' command is deprecated and will stop working in a future minor release. Please use the 'mounts' command instead. If you use 'all' no change is required.\n\n")
+
 	if len(report.ResultsWithMinSeverity(p.minSeverity)) < 1 {
 		p.printColor(color.GreenColor, "All checks completed. 0 high-risk vulnerabilities found\n")
+		return
 	}
 
 	for _, workloadResult := range report.ResultsWithMinSeverity(p.minSeverity) {


### PR DESCRIPTION
Removes `mountds` from the `all` command (should be a no-op since the `mounts` command tests for the same things and more).

Also adds a deprecation notice at the top of the results (if using pretty print output)

> DEPRECATION NOTICE: The 'mountds' command is deprecated and will stop working in a future minor release. Please use the 'mounts' command instead. If you use 'all' no change is required