### PR TITLE
Remove example dependency on internal packages

### DIFF
--- a/example_custom_test.go
+++ b/example_custom_test.go
@@ -21,7 +21,7 @@ type myAuditor struct{}
 //
 // Params
 //   resource: Read-only. The resource to audit.
-//   resources: Read-only. A reference to all resources. Can be used for context.
+//   resources: Read-only. A reference to all resources. Can be used for context though most auditors don't need this.
 //
 // Return
 //   auditResults: The results for the audit. Each result can optionally include a PendingFix object to

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Shopify/kubeaudit/auditors/apparmor"
 	"github.com/Shopify/kubeaudit/auditors/image"
 	"github.com/Shopify/kubeaudit/config"
-	"github.com/Shopify/kubeaudit/internal/k8s"
 
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
@@ -79,7 +78,7 @@ func Example_auditLocal() {
 	}
 
 	// Run the audit in local mode
-	report, err := auditor.AuditLocal("", k8s.ClientOptions{})
+	report, err := auditor.AuditLocal("", kubeaudit.AuditOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -103,7 +102,7 @@ func Example_auditCluster() {
 	}
 
 	// Run the audit in cluster mode. Note this will fail if kubeaudit is not running within a cluster.
-	report, err := auditor.AuditCluster(k8s.ClientOptions{})
+	report, err := auditor.AuditCluster(kubeaudit.AuditOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -114,6 +113,19 @@ func Example_auditCluster() {
 
 // ExampleAuditorSubset shows how to run kubeaudit with a subset of auditors
 func Example_auditorSubset() {
+	// A sample Kubernetes manifest file
+	manifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myAuditor 
+  spec:
+    template:
+      spec:
+        containers:
+        - name: myContainer
+`
+
 	// Initialize the auditors you want to use
 	auditor, err := kubeaudit.New([]kubeaudit.Auditable{
 		apparmor.New(),
@@ -138,6 +150,18 @@ func Example_auditorSubset() {
 // for those auditors.
 func Example_config() {
 	configFile := "config/config.yaml"
+	// A sample Kubernetes manifest file
+	manifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myAuditor 
+  spec:
+    template:
+      spec:
+        containers:
+        - name: myContainer
+`
 
 	// Open the configuration file
 	reader, err := os.Open(configFile)
@@ -180,7 +204,7 @@ func Example_printOptions() {
 		log.Fatal(err)
 	}
 
-	report, err := auditor.AuditLocal("", k8s.ClientOptions{})
+	report, err := auditor.AuditLocal("", kubeaudit.AuditOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/kubeaudit.go
+++ b/kubeaudit.go
@@ -112,6 +112,8 @@ type Kubeaudit struct {
 	auditors []Auditable
 }
 
+type AuditOptions = k8s.ClientOptions
+
 // New returns a new Kubeaudit instance
 func New(auditors []Auditable, opts ...Option) (*Kubeaudit, error) {
 	if len(auditors) == 0 {
@@ -152,7 +154,7 @@ func (a *Kubeaudit) AuditManifest(manifest io.Reader) (*Report, error) {
 }
 
 // AuditCluster audits the Kubernetes resources found in the cluster in which Kubeaudit is running
-func (a *Kubeaudit) AuditCluster(options k8s.ClientOptions) (*Report, error) {
+func (a *Kubeaudit) AuditCluster(options AuditOptions) (*Report, error) {
 	if !k8s.IsRunningInCluster(k8s.DefaultClient) {
 		return nil, errors.New("failed to audit resources in cluster mode: not running in cluster")
 	}
@@ -174,7 +176,7 @@ func (a *Kubeaudit) AuditCluster(options k8s.ClientOptions) (*Report, error) {
 }
 
 // AuditLocal audits the Kubernetes resources found in the provided Kubernetes config file
-func (a *Kubeaudit) AuditLocal(configpath string, options k8s.ClientOptions) (*Report, error) {
+func (a *Kubeaudit) AuditLocal(configpath string, options AuditOptions) (*Report, error) {
 	clientset, err := k8s.NewKubeClientLocal(configpath)
 	if err == k8s.ErrNoReadableKubeConfig {
 		return nil, fmt.Errorf("failed to open kubeconfig file %s", configpath)


### PR DESCRIPTION
##### Description

The examples for using kubeaudit as a package didn't work outside the kubeaudit repo because they had dependencies on internal packages. This adds an alias in the kubeaudit package root such that the relevant type can be imported outside of the kubeaudit repo.

Fixes https://github.com/Shopify/kubeaudit/issues/298

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Run the examples in a `main.go` file outside of the kubeaudit repo with a go mod replace statement to point the kubeaudit import to my local repo

##### Checklist:

- [ ] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [ ] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
