### PR TITLE
Add option to disable printing results in color

### DIFF
--- a/kubeaudit.go
+++ b/kubeaudit.go
@@ -58,17 +58,23 @@
 //
 // Or, to run the audit in local mode:
 //
-//   report, err := kubeAuditor.AuditLocal("/path/to/kubeconfig.yml")
+//   report, err := kubeAuditor.AuditLocal("/path/to/kubeconfig.yml", kubeaudit.AuditOptions{})
 //
 // Or, to run the audit in cluster mode (pass it a namespace name as a string to only audit resources in that namespace, or an empty string to audit resources in all namespaces):
 //
-//   report, err := auditor.AuditCluster("")
+//   report, err := auditor.AuditCluster(kubeaudit.AuditOptions{})
 //
 // Get the results
 //
 // To print the results in a human readable way:
 //
-//   report.PrintResults(os.Stdout, kubeaudit.Info, nil)
+//   report.PrintResults()
+//
+// Results are printed to standard out by default. To print to a string instead:
+//
+//   var buf bytes.Buffer
+//   report.PrintResults(kubeaudit.WithWriter(&buf), kubeaudit.WithColor(false))
+//   resultsString := buf.String()
 //
 // Or, to get the result objects:
 //

--- a/printer.go
+++ b/printer.go
@@ -20,21 +20,32 @@ type Printer struct {
 
 type PrintOption func(p *Printer)
 
+// WithMinSeverity sets the minimum severity of results that will be printed.
 func WithMinSeverity(minSeverity SeverityLevel) PrintOption {
 	return func(p *Printer) {
 		p.minSeverity = minSeverity
 	}
 }
 
+// WithWriter sets the writer where results will be written to.
 func WithWriter(writer io.Writer) PrintOption {
 	return func(p *Printer) {
 		p.writer = writer
 	}
 }
 
+// WithFormatter sets a logrus formatter to use to format results.
 func WithFormatter(formatter log.Formatter) PrintOption {
 	return func(p *Printer) {
 		p.formatter = formatter
+	}
+}
+
+// WithColor specifies whether or not to colorize output. You will likely want to set this to false if
+// not writing to standard out.
+func WithColor(color bool) PrintOption {
+	return func(p *Printer) {
+		p.color = color
 	}
 }
 
@@ -48,11 +59,9 @@ func NewPrinter(opts ...PrintOption) Printer {
 	p := Printer{
 		writer:      os.Stdout,
 		minSeverity: Info,
+		color:       true,
 	}
 	p.parseOptions(opts...)
-	if p.writer == os.Stdout {
-		p.color = true
-	}
 	return p
 }
 


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description

Exposes a `WithColor` printer option that can be used to disable color formatting when printing results.

##### Type of change

<!-- Please delete options that are not relevant. --->
- [ ] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [NA] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
