### PR TITLE
Remove wip probot

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -3,4 +3,3 @@ enabled:
   - welcome
   - triage-new-issues
   - probot-labeler
-  - wip


### PR DESCRIPTION
The wip probot check is blocking dependabot PRs from passing CI... 

![image](https://user-images.githubusercontent.com/11131143/137807916-84ea65a2-616b-4c5d-aeb3-2a192f6a3700.png)

Since we don't have time to debug this right now, it's probably more desirable to get dependabot PRs shipped. I also removed the branch protection that required the check to pass.
