### PR TITLE
Add support for kind Job

### DIFF
--- a/internal/k8sinternal/client_test.go
+++ b/internal/k8sinternal/client_test.go
@@ -80,6 +80,7 @@ func TestGetAllResources(t *testing.T) {
 		k8s.NewCronJob(),
 		k8s.NewServiceAccount(),
 		k8s.NewService(),
+		k8s.NewJob(),
 	}
 	namespaces := []string{"foo", "bar"}
 

--- a/internal/test/fixtures/all_resources/job.yml
+++ b/internal/test/fixtures/all_resources/job.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: job
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job
+  namespace: job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      containers:
+        - name: container
+          image: scratch

--- a/pkg/k8s/helpers.go
+++ b/pkg/k8s/helpers.go
@@ -65,6 +65,8 @@ func GetObjectMeta(resource Resource) *ObjectMetaV1 {
 		return &kubeType.ObjectMeta
 	case *DeploymentV1Beta2:
 		return &kubeType.ObjectMeta
+	case *JobV1:
+		return &kubeType.ObjectMeta
 	case *PodTemplateV1:
 		return &kubeType.ObjectMeta
 	case *ReplicationControllerV1:
@@ -136,6 +138,8 @@ func GetPodTemplateSpec(resource Resource) *PodTemplateSpecV1 {
 	case *DeploymentV1Beta1:
 		return &kubeType.Spec.Template
 	case *DeploymentV1Beta2:
+		return &kubeType.Spec.Template
+	case *JobV1:
 		return &kubeType.Spec.Template
 	case *PodTemplateV1:
 		return &kubeType.Template

--- a/pkg/k8s/resources.go
+++ b/pkg/k8s/resources.go
@@ -148,3 +148,17 @@ func NewService() *ServiceV1 {
 		ObjectMeta: ObjectMetaV1{},
 	}
 }
+
+// NewJob creates a new Job resource
+func NewJob() *JobV1 {
+	return &JobV1{
+		TypeMeta: TypeMetaV1{
+			Kind:       "Job",
+			APIVersion: "batch/v1",
+		},
+		ObjectMeta: ObjectMetaV1{},
+		Spec: JobSpecV1{
+			Template: podTemplateSpec,
+		},
+	}
+}

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -61,6 +61,9 @@ type JobTemplateSpecV1Beta1 = batchv1beta1.JobTemplateSpec
 // JobSpecV1 is a type alias for the v1 version of the k8s batch API.
 type JobSpecV1 = batchv1.JobSpec
 
+// JobV1 is a type alias for the v1 version of the k8s batch API.
+type JobV1 = batchv1.Job
+
 // ListOptionsV1 is a type alias for the v1 version of the k8s meta API.
 type ListOptionsV1 = metav1.ListOptions
 
@@ -136,6 +139,7 @@ func IsSupportedResourceType(obj Resource) bool {
 	case *CronJobV1Beta1,
 		*DaemonSetV1, *DaemonSetV1Beta1, *DaemonSetV1Beta2,
 		*DeploymentExtensionsV1Beta1, *DeploymentV1, *DeploymentV1Beta1, *DeploymentV1Beta2,
+		*JobV1,
 		*NamespaceV1,
 		*NetworkPolicyV1,
 		*PodV1,


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR adds support for kind `Job`.  Currently, `Job` is an unsupported resource in kubeaudit.

```
---------------- Results for ---------------

  apiVersion: batch/v1
  kind: Job

--------------------------------------------

-- [warning] Unsupported resource
   Message: Resource is not currently supported.
```

##### Type of change

<!-- Please delete options that are not relevant. --->
- [ ] Bug fix :bug:
- [x] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

```
$ make test
./test.sh
Starting tests. This may take a while...
make[1]: Entering directory '/home/ksuda/src/github.com/Shopify/kubeaudit'
kind create cluster --name "kubeaudit-test" --image kindest/node:v1.15.0
Creating cluster "kubeaudit-test" ...
 ✓ Ensuring node image (kindest/node:v1.15.0) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
Could not read storage manifest, falling back on old k8s.io/host-path default ...
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-kubeaudit-test"
You can now use your cluster with:

kubectl cluster-info --context kind-kubeaudit-test

Thanks for using kind! 😊
make[1]: Leaving directory '/home/ksuda/src/github.com/Shopify/kubeaudit'
ok      github.com/Shopify/kubeaudit    0.256s  coverage: 71.6% of statements
ok      github.com/Shopify/kubeaudit/auditors/all       37.277s coverage: 92.6% of statements
ok      github.com/Shopify/kubeaudit/auditors/apparmor  21.842s coverage: 100.0% of statements
ok      github.com/Shopify/kubeaudit/auditors/asat      22.415s coverage: 100.0% of statements
ok      github.com/Shopify/kubeaudit/auditors/capabilities      22.476s coverage: 94.8% of statements
ok      github.com/Shopify/kubeaudit/auditors/hostns    22.451s coverage: 92.1% of statements
ok      github.com/Shopify/kubeaudit/auditors/image     22.081s coverage: 96.4% of statements
ok      github.com/Shopify/kubeaudit/auditors/limits    22.299s coverage: 98.6% of statements
ok      github.com/Shopify/kubeaudit/auditors/mounts    107.929s        coverage: 89.2% of statements
ok      github.com/Shopify/kubeaudit/auditors/netpols   6.172s  coverage: 90.4% of statements
ok      github.com/Shopify/kubeaudit/auditors/nonroot   84.773s coverage: 95.7% of statements
ok      github.com/Shopify/kubeaudit/auditors/privesc   22.208s coverage: 100.0% of statements
ok      github.com/Shopify/kubeaudit/auditors/privileged        22.170s coverage: 95.5% of statements
ok      github.com/Shopify/kubeaudit/auditors/rootfs    22.169s coverage: 95.5% of statements
ok      github.com/Shopify/kubeaudit/auditors/seccomp   22.105s coverage: 100.0% of statements
?       github.com/Shopify/kubeaudit/cmd        [no test files]
?       github.com/Shopify/kubeaudit/cmd/commands       [no test files]
ok      github.com/Shopify/kubeaudit/config     0.053s  coverage: 57.1% of statements
?       github.com/Shopify/kubeaudit/internal/color     [no test files]
ok      github.com/Shopify/kubeaudit/internal/k8sinternal       0.298s  coverage: 83.9% of statements
?       github.com/Shopify/kubeaudit/internal/test      [no test files]
ok      github.com/Shopify/kubeaudit/internal/yaml      0.028s  coverage: 89.0% of statements
ok      github.com/Shopify/kubeaudit/pkg/fix    0.050s  coverage: 94.4% of statements
?       github.com/Shopify/kubeaudit/pkg/k8s    [no test files]
?       github.com/Shopify/kubeaudit/pkg/override       [no test files]
make[1]: Entering directory '/home/ksuda/src/github.com/Shopify/kubeaudit'
kind delete cluster --name "kubeaudit-test"
Deleting cluster "kubeaudit-test" ...
make[1]: Leaving directory '/home/ksuda/src/github.com/Shopify/kubeaudit'
```

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease: I added a new fixture.: I could not check coverage decreased or not because tests failed on the main branch.
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
