### PR TITLE
Fix deadlink in seccomp auditor docs

### DIFF
--- a/docs/auditors/seccomp.md
+++ b/docs/auditors/seccomp.md
@@ -67,7 +67,7 @@ spec:
 
 To learn more about Seccomp, see https://en.wikipedia.org/wiki/Seccomp
 
-To learn more about Seccomp in Kubernetes, see https://gardener.cloud/050-tutorials/content/howto/secure-seccomp/
+To learn more about Seccomp in Kubernetes, see https://kubernetes.io/docs/tutorials/security/seccomp/
 
 ## Override Errors
 


### PR DESCRIPTION
##### Description

Replace dead link to gardener.cloud seccomp tutorial with official kubernetes seccomp tutorial.

##### Type of change

- [x] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning: