### PR TITLE
🐛 Ignore groups not served  by the cluster

### DIFF
--- a/internal/k8sinternal/client.go
+++ b/internal/k8sinternal/client.go
@@ -212,7 +212,8 @@ func (kc kubeClient) GetKubernetesVersion() (*version.Info, error) {
 func (kc kubeClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	list, err := discovery.ServerPreferredResources(kc.discoveryClient)
 	// If a group is not served by the cluster the resources of this group will not be audited.
-	if _, ok := err.(*discovery.ErrGroupDiscoveryFailed); ok {
+	var e *discovery.ErrGroupDiscoveryFailed
+	if errors.As(err, &e) {
 		return list, nil
 	}
 	return list, err

--- a/internal/k8sinternal/client.go
+++ b/internal/k8sinternal/client.go
@@ -106,7 +106,7 @@ type ClientOptions struct {
 
 type KubeClient interface {
 	// GetAllResources gets all supported resources from the cluster
-	GetAllResources(options ClientOptions) []k8s.Resource
+	GetAllResources(options ClientOptions) ([]k8s.Resource, error)
 	// GetKubernetesVersion returns the kubernetes client version
 	GetKubernetesVersion() (*version.Info, error)
 	// ServerPreferredResources returns the supported resources with the version preferred by the server.
@@ -123,11 +123,14 @@ func NewKubeClient(dynamic dynamic.Interface, discovery discovery.DiscoveryInter
 }
 
 // GetAllResources gets all supported resources from the cluster
-func (kc kubeClient) GetAllResources(options ClientOptions) []k8s.Resource {
+func (kc kubeClient) GetAllResources(options ClientOptions) ([]k8s.Resource, error) {
 	var resources []k8s.Resource
 
 	lists, err := kc.ServerPreferredResources()
-	if err == nil {
+	if err != nil {
+		return nil, err
+	}
+	if lists != nil {
 		for _, list := range lists {
 			if len(list.APIResources) == 0 {
 				continue
@@ -169,7 +172,7 @@ func (kc kubeClient) GetAllResources(options ClientOptions) []k8s.Resource {
 	if !options.IncludeGenerated {
 		resources = excludeGenerated(resources)
 	}
-	return resources
+	return resources, nil
 }
 
 // unstructuredToObject unstructured to Go typed object conversions
@@ -207,5 +210,10 @@ func (kc kubeClient) GetKubernetesVersion() (*version.Info, error) {
 
 // ServerPreferredResources returns the supported resources with the version preferred by the server.
 func (kc kubeClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
-	return discovery.ServerPreferredResources(kc.discoveryClient)
+	list, err := discovery.ServerPreferredResources(kc.discoveryClient)
+	// If a group is not served by the cluster the resources of this group will not be audited.
+	if _, ok := err.(*discovery.ErrGroupDiscoveryFailed); ok {
+		return list, nil
+	}
+	return list, err
 }

--- a/internal/k8sinternal/client_test.go
+++ b/internal/k8sinternal/client_test.go
@@ -102,12 +102,13 @@ func TestGetAllResources(t *testing.T) {
 	}
 
 	client := newFakeKubeClient(resources...)
-	assert.Len(t, client.GetAllResources(k8sinternal.ClientOptions{}), len(resourceTemplates)*len(namespaces))
-	assert.Len(
-		t,
-		client.GetAllResources(k8sinternal.ClientOptions{Namespace: namespaces[0]}),
-		len(resourceTemplates),
-	)
+	k8sresources, err := client.GetAllResources(k8sinternal.ClientOptions{})
+	require.NoError(t, err)
+	assert.Len(t, k8sresources, len(resourceTemplates)*len(namespaces))
+
+	k8sresources, err = client.GetAllResources(k8sinternal.ClientOptions{Namespace: namespaces[0]})
+	require.NoError(t, err)
+	assert.Len(t, k8sresources, len(resourceTemplates))
 }
 
 func setNamespace(resource k8s.Resource, namespace string) {
@@ -147,21 +148,24 @@ func TestIncludeGenerated(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test IncludeGenerated = false
-	resources := client.GetAllResources(
+	resources, err := client.GetAllResources(
 		k8sinternal.ClientOptions{Namespace: namespace, IncludeGenerated: false},
 	)
+	require.NoError(t, err)
 	assert.False(t, hasPod(resources), "Expected no pods for IncludeGenerated=false")
 
 	// Test IncludeGenerated unspecified defaults to false
-	resources = client.GetAllResources(
+	resources, err = client.GetAllResources(
 		k8sinternal.ClientOptions{Namespace: namespace},
 	)
+	require.NoError(t, err)
 	assert.False(t, hasPod(resources), "Expected no pods if IncludeGenerated is unspecified (ie. default to false)")
 
 	// Test IncludeGenerated = true
-	resources = client.GetAllResources(
+	resources, err = client.GetAllResources(
 		k8sinternal.ClientOptions{Namespace: namespace, IncludeGenerated: true},
 	)
+	require.NoError(t, err)
 	assert.True(t, hasPod(resources), "Expected pods for IncludeGenerated=true")
 }
 

--- a/kubeaudit.go
+++ b/kubeaudit.go
@@ -170,7 +170,10 @@ func (a *Kubeaudit) AuditCluster(options AuditOptions) (*Report, error) {
 		return nil, err
 	}
 
-	resources := getResourcesFromClient(client, options)
+	resources, err := getResourcesFromClient(client, options)
+	if err != nil {
+		return nil, err
+	}
 	results, err := auditResources(resources, a.auditors)
 	if err != nil {
 		return nil, err
@@ -190,7 +193,10 @@ func (a *Kubeaudit) AuditLocal(configpath string, options AuditOptions) (*Report
 		return nil, err
 	}
 
-	resources := getResourcesFromClient(client, options)
+	resources, err := getResourcesFromClient(client, options)
+	if err != nil {
+		return nil, err
+	}
 	results, err := auditResources(resources, a.auditors)
 	if err != nil {
 		return nil, err

--- a/util.go
+++ b/util.go
@@ -9,14 +9,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func getResourcesFromClient(client k8sinternal.KubeClient, options k8sinternal.ClientOptions) []KubeResource {
+func getResourcesFromClient(client k8sinternal.KubeClient, options k8sinternal.ClientOptions) ([]KubeResource, error) {
 	var resources []KubeResource
 
-	for _, resource := range client.GetAllResources(options) {
+	k8sresources, err := client.GetAllResources(options)
+	if err != nil {
+		return nil, err
+	}
+	for _, resource := range k8sresources {
 		resources = append(resources, &kubeResource{object: resource})
 	}
 
-	return resources
+	return resources, nil
 }
 
 func getResourcesFromManifest(data []byte) ([]KubeResource, error) {


### PR DESCRIPTION
##### Description

If a group is not available on a server the `discovery.ServerPreferredResources` function returns  the list of preferred resources but also an [`ErrGroupDiscoveryFailed`](https://github.com/kubernetes/client-go/blob/v0.24.1/discovery/discovery_client.go#L331) error with the groups not available. 

This error can be ignored  because the unavailable resource types  should not be audited.

#
This is an example of a cluster with the `external.metrics.k8s.io` group not available:
```
$ kubectl  get apiservice v1beta1.external.metrics.k8s.io 
NAME                              SERVICE                    AVAILABLE                      AGE
v1beta1.external.metrics.k8s.io   my-custom-metrics-server   False (FailedDiscoveryCheck)   22d
```
```
$ kubectl  get --raw /apis/external.metrics.k8s.io/v1beta1
Error from server (ServiceUnavailable): the server is currently unable to handle the request
```
If we have a cluster in this state no resources are audited because an error is returned by ` discovery.ServerPreferredResources`
https://github.com/Shopify/kubeaudit/blob/6a30cc08c46cee8922f451b0449923b7a3ec761b/internal/k8sinternal/client.go#L129-L130


#
##### Type of change

- [x] Bug fix :bug:

##### How Has This Been Tested?

- [x] Automated tests still work
- [x] Manual tests: The `kubeaudit all` command was tested on a cluster with an unavailable  `external.metrics.k8s.io` group. Without this fix no reports are displayed,  with the fix the reports are provided as expected.
  
##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
