### PR TITLE
uses gh actions instead of probot

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,6 +1,0 @@
-core: ["/cmd"]
-legal: ["LICENSE*", "CODE_OF_CONDUCT*"]
-config: [".github","build","Makefile","/configs"]
-go-modules: ["go.*"]
-readme: ["README*"]
-datafiles: ["/fixtures"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+core:
+- '/cmd'
+
+legal:
+- any: ['LICENSE*', 'CODE_OF_CONDUCT*']
+
+config:
+- any: ['.github','build','Makefile','/config']
+
+go-modules:
+- 'go.*'
+
+readme:
+- 'README*'
+
+datafiles:
+- '/fixtures'

--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,4 +1,0 @@
-enabled:
-  - welcome
-  - triage-new-issues
-  - probot-labeler

--- a/.github/welcome.yml
+++ b/.github/welcome.yml
@@ -1,8 +1,0 @@
-newIssueWelcomeComment: >
-  Thanks for opening your first issue here! Be sure to follow the issue template!
-
-newPRWelcomeComment: >
-  Thanks for opening this pull request! Please check out our [contributing guidelines](https://github.com/Shopify/kubeaudit#Contributing) and [sign the CLA](https://cla.shopify.com/).
-
-firstPRMergeComment: >
-  Congrats on merging your first pull request, keep em coming!

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,6 @@
+steps:
+- uses: actions/first-interaction@v1
+  with:
+    repo-token: ${{ secrets.GITHUB_TOKEN }}
+    issue-message: 'Thanks for opening your first issue here! Be sure to follow the issue template!'
+    pr-message: 'Thanks for opening this pull request! Please check out our [contributing guidelines](https://github.com/Shopify/kubeaudit#Contributing) and [sign the CLA](https://cla.shopify.com/).'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR migrates off probot and favors GH actions instead.

Caveats:
  - [welcome](https://github.com/marketplace/actions/first-interaction) => we're missing a celebration when folks merge their PRs. I don't think this field is supported by the GH action
  - triage-new-issues => There is no equivalent. Triaging issues will have to be done manually (if we think it's worth it, we can write our own action for that in a a follow-up PR)
  
##### Type of change
workflow / dev / contributions