### PR TITLE
adds metadata to sarif result

### DIFF
--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -45,7 +45,7 @@ func Create(kubeauditReport *kubeaudit.Report) (*sarif.Report, error) {
 
 		metadata, jsonErr := json.Marshal(formattedMap)
 
-		if err != nil {
+		if jsonErr != nil {
 			metadata = []byte(jsonErr.Error())
 		}
 

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -40,18 +40,23 @@ func Create(kubeauditReport *kubeaudit.Report) (*sarif.Report, error) {
 		formattedMap := make(map[string]string)
 
 		for k, v := range result.Metadata {
-			formattedMap[k] = "`" + v + "`"
+			formattedMap[k] = v
 		}
 
 		metadata, jsonErr := json.Marshal(formattedMap)
-
 		if jsonErr != nil {
 			metadata = []byte(jsonErr.Error())
 		}
 
+		var metadataTxt string
+
+		if len(formattedMap) > 0 {
+			metadataTxt = fmt.Sprintf("Metadata: %s\n", string(metadata))
+		}
+
 		docsURL := "https://github.com/Shopify/kubeaudit/blob/main/docs/auditors/" + auditor + ".md"
 
-		helpText := fmt.Sprintf("Type: kubernetes\nAuditor Docs: To find out more about the issue and how to fix it, follow [this link](%s)\nDescription: %s\nMetadata: %s\n\n Note: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ", docsURL, allAuditors[auditor], string(metadata))
+		helpText := fmt.Sprintf("Type: kubernetes\nAuditor Docs: To find out more about the issue and how to fix it, follow [this link](%s)\nDescription: %s\n%s\n\n Note: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ", docsURL, allAuditors[auditor], metadataTxt)
 
 		helpMarkdown := fmt.Sprintf("**Type**: kubernetes\n**Auditor Docs**: To find out more about the issue and how to fix it, follow [this link](%s)\n**Description:** %s\n **Metadata**: %s\n\n *Note*: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ",
 			docsURL, allAuditors[auditor], string(metadata))

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -2,6 +2,7 @@ package sarif
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -36,12 +37,24 @@ func Create(kubeauditReport *kubeaudit.Report) (*sarif.Report, error) {
 
 		auditor := strings.ToLower(result.Auditor)
 
+		formattedMap := make(map[string]string)
+
+		for k, v := range result.Metadata {
+			formattedMap[k] = "`" + v + "`"
+		}
+
+		metadata, jsonErr := json.Marshal(formattedMap)
+
+		if err != nil {
+			metadata = []byte(jsonErr.Error())
+		}
+
 		docsURL := "https://github.com/Shopify/kubeaudit/blob/main/docs/auditors/" + auditor + ".md"
 
-		helpText := fmt.Sprintf("Type: kubernetes\nAuditor Docs: To find out more about the issue and how to fix it, follow [this link](%s)\nDescription: %s\n\n Note: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ", docsURL, allAuditors[auditor])
+		helpText := fmt.Sprintf("Type: kubernetes\nAuditor Docs: To find out more about the issue and how to fix it, follow [this link](%s)\nDescription: %s\nMetadata: %s\n\n Note: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ", docsURL, allAuditors[auditor], string(metadata))
 
-		helpMarkdown := fmt.Sprintf("**Type**: kubernetes\n**Auditor Docs**: To find out more about the issue and how to fix it, follow [this link](%s)\n**Description:** %s\n\n *Note*: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ",
-			docsURL, allAuditors[auditor])
+		helpMarkdown := fmt.Sprintf("**Type**: kubernetes\n**Auditor Docs**: To find out more about the issue and how to fix it, follow [this link](%s)\n**Description:** %s\n **Metadata**: %s\n\n *Note*: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ",
+			docsURL, allAuditors[auditor], string(metadata))
 
 		// we only add rules to the report based on the result findings
 		run.AddRule(result.Rule).

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -37,20 +37,19 @@ func Create(kubeauditReport *kubeaudit.Report) (*sarif.Report, error) {
 
 		auditor := strings.ToLower(result.Auditor)
 
-		formattedMap := make(map[string]string)
-
-		for k, v := range result.Metadata {
-			formattedMap[k] = v
-		}
-
-		metadata, jsonErr := json.Marshal(formattedMap)
-		if jsonErr != nil {
-			metadata = []byte(jsonErr.Error())
-		}
-
 		var metadataTxt string
+		if len(result.Metadata) > 0 {
+			formattedMap := make(map[string]string)
 
-		if len(formattedMap) > 0 {
+			for k, v := range result.Metadata {
+				formattedMap[k] = v
+			}
+
+			metadata, jsonErr := json.Marshal(formattedMap)
+			if jsonErr != nil {
+				metadata = []byte(jsonErr.Error())
+			}
+
 			metadataTxt = fmt.Sprintf("Metadata: %s\n", string(metadata))
 		}
 
@@ -59,7 +58,7 @@ func Create(kubeauditReport *kubeaudit.Report) (*sarif.Report, error) {
 		helpText := fmt.Sprintf("Type: kubernetes\nAuditor Docs: To find out more about the issue and how to fix it, follow [this link](%s)\nDescription: %s\n%s\n\n Note: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ", docsURL, allAuditors[auditor], metadataTxt)
 
 		helpMarkdown := fmt.Sprintf("**Type**: kubernetes\n**Auditor Docs**: To find out more about the issue and how to fix it, follow [this link](%s)\n**Description:** %s\n **Metadata**: %s\n\n *Note*: These audit results are generated with `kubeaudit`, a command line tool and a Go package that checks for potential security concerns in kubernetes manifest specs. You can read more about it at https://github.com/Shopify/kubeaudit ",
-			docsURL, allAuditors[auditor], string(metadata))
+			docsURL, allAuditors[auditor], metadataTxt)
 
 		// we only add rules to the report based on the result findings
 		run.AddRule(result.Rule).


### PR DESCRIPTION
This is to add the Metadata field/info to the sarif. We currently display this info on the CLI. but it was missing on the sarif. Here's an example of what it will look like on Github UI:


<img width="924" alt="Screenshot 2023-01-23 at 5 45 14 PM" src="https://user-images.githubusercontent.com/22174780/214166725-f82450d3-cd63-4f0d-a835-7c6692c36e1c.png">
