### PR TITLE
By default, test without Kind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,6 @@ jobs:
       - name: Go mod download and go tidy
         run: make setup
       - name: Run tests
+        env:
+          USE_KIND: "true"
         run: make test

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ If you'd like to fix a bug, contribute a feature or just correct a typo, please 
 1. Add your forked repo as a fork: `git remote add fork https://github.com/you-are-awesome/kubeaudit`
 1. Create your feature branch: `git checkout -b awesome-new-feature`
 1. Install [Kind](https://kind.sigs.k8s.io/#installation-and-usage)
-1. Run the tests to see everything is working as expected: `make test` (to run tests without Kind: `USE_KIND=false make test`)
+1. Run the tests to see everything is working as expected: `USE_KIND=true make test` (to run tests without Kind: `make test`)
 1. Commit your changes: `git commit -am 'Adds awesome feature'`
 1. Push to the branch: `git push fork`
 1. Sign the [Contributor License Agreement](https://cla.shopify.com/)

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -137,7 +137,7 @@ func GetAllFileNames(t *testing.T, directory string) []string {
 
 // UseKind returns true if tests which utilize Kind should run
 func UseKind() bool {
-	return os.Getenv("USE_KIND") != "false"
+	return os.Getenv("USE_KIND") == "true"
 }
 
 func ApplyManifest(t *testing.T, manifestPath, namespace string) {

--- a/kubeaudit_test.go
+++ b/kubeaudit_test.go
@@ -1,7 +1,6 @@
 package kubeaudit_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Shopify/kubeaudit"
@@ -29,7 +28,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestAuditLocal(t *testing.T) {
-	if os.Getenv("USE_KIND") == "false" {
+	if !test.UseKind() {
 		return
 	}
 

--- a/test.sh
+++ b/test.sh
@@ -5,13 +5,13 @@ set -e
 echo "Starting tests. This may take a while..."
 
 function finish {
-    if [ "$USE_KIND" != "false" ] ; then
+    if [ "$USE_KIND" == "true" ] ; then
         make test-teardown
     fi
 }
 trap finish EXIT
 
-if [ "$USE_KIND" != "false" ] ; then
+if [ "$USE_KIND" == "true" ] ; then
     make test-setup
 fi
 


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Instead of running tests in a "Kind" environment by default, explicitly enable Kind. This prevents accidentally running cluster tests against a production cluster with `go test ./...` (as opposed to `make test` which would first activate the Kind cluster).

##### Type of change

<!-- Please delete options that are not relevant. --->
- [ ] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

##### Checklist:

- [ ] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [ ] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
