### PR TITLE
remove refs to old annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,13 @@ The `key` is a combination of the override type (container or pod) and an `overr
 1. **Container overrides**, which override the auditor for that specific container, are formatted as follows:
 
 ```yaml
-container.audit.kubernetes.io/[container name].[override identifier]
+container.audit.kubeaudit.io/[container name].[override identifier]
 ```
 
 2. **Pod overrides**, which override the auditor for all containers within the pod, are formatted as follows:
 
 ```yaml
-audit.kubernetes.io/pod.[override identifier]
+audit.kubeaudit.io/pod.[override identifier]
 ```
 
 If the `value` is set to a non-empty string, it will be displayed in the `info` result as the `OverrideReason`:

--- a/auditors/apparmor/fixtures/apparmor-bad-value-override.yml
+++ b/auditors/apparmor/fixtures/apparmor-bad-value-override.yml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     container.apparmor.security.beta.kubernetes.io/container: badval
   labels:
-    container.audit.kubernetes.io/container.allow-disabled-apparmor: "SomeReason"
+    container.audit.kubeaudit.io/container.allow-disabled-apparmor: "SomeReason"
 spec:
   containers:
     - name: container

--- a/auditors/apparmor/fixtures/apparmor-disabled-overriden-multiple.yml
+++ b/auditors/apparmor/fixtures/apparmor-disabled-overriden-multiple.yml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     container.apparmor.security.beta.kubernetes.io/container2: unconfined
   labels:
-    container.audit.kubernetes.io/container2.allow-disabled-apparmor: "SomeReason"
+    container.audit.kubeaudit.io/container2.allow-disabled-apparmor: "SomeReason"
 spec:
   containers:
     - name: container

--- a/auditors/apparmor/fixtures/apparmor-disabled-overriden.yml
+++ b/auditors/apparmor/fixtures/apparmor-disabled-overriden.yml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     container.apparmor.security.beta.kubernetes.io/container: unconfined
   labels:
-    container.audit.kubernetes.io/container.allow-disabled-apparmor: "SomeReason"
+    container.audit.kubeaudit.io/container.allow-disabled-apparmor: "SomeReason"
 spec:
   containers:
     - name: container

--- a/auditors/asat/fixtures/service-account-token-redundant-override.yml
+++ b/auditors/asat/fixtures/service-account-token-redundant-override.yml
@@ -8,7 +8,7 @@ spec:
     metadata:
       labels:
         name: replicationcontroller
-        audit.kubernetes.io/pod.allow-automount-service-account-token: "SomeReason"
+        audit.kubeaudit.io/pod.allow-automount-service-account-token: "SomeReason"
     spec:
       automountServiceAccountToken: false
       containers:

--- a/auditors/asat/fixtures/service-account-token-true-allowed.yml
+++ b/auditors/asat/fixtures/service-account-token-true-allowed.yml
@@ -8,7 +8,7 @@ spec:
     metadata:
       labels:
         name: replicationcontroller
-        audit.kubernetes.io/pod.allow-automount-service-account-token: "SomeReason"
+        audit.kubeaudit.io/pod.allow-automount-service-account-token: "SomeReason"
     spec:
       automountServiceAccountToken: true
       containers:

--- a/auditors/capabilities/fixtures/capabilities-some-allowed-multi-containers-all-labels.yml
+++ b/auditors/capabilities/fixtures/capabilities-some-allowed-multi-containers-all-labels.yml
@@ -11,10 +11,10 @@ spec:
     metadata:
       labels:
         name: deployment
-        container.audit.kubernetes.io/container1.allow-capability-chown: "SomeReason"
-        container.audit.kubernetes.io/container1.allow-capability-sys-time: "SomeReason"
-        container.audit.kubernetes.io/container2.allow-capability-chown: "SomeReason"
-        container.audit.kubernetes.io/container2.allow-capability-sys-time: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-capability-chown: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-capability-sys-time: "SomeReason"
+        container.audit.kubeaudit.io/container2.allow-capability-chown: "SomeReason"
+        container.audit.kubeaudit.io/container2.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
         - name: container1

--- a/auditors/capabilities/fixtures/capabilities-some-allowed-multi-containers-mix-labels.yml
+++ b/auditors/capabilities/fixtures/capabilities-some-allowed-multi-containers-mix-labels.yml
@@ -11,10 +11,10 @@ spec:
     metadata:
       labels:
         name: deployment
-        audit.kubernetes.io/pod.allow-capability-chown: "SomeReason"
-        container.audit.kubernetes.io/container1.allow-capability-chown: "SomeReason"
-        container.audit.kubernetes.io/container1.allow-capability-sys-time: "SomeReason"
-        container.audit.kubernetes.io/container2.allow-capability-sys-time: "SomeReason"
+        audit.kubeaudit.io/pod.allow-capability-chown: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-capability-chown: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-capability-sys-time: "SomeReason"
+        container.audit.kubeaudit.io/container2.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
         - name: container1

--- a/auditors/capabilities/fixtures/capabilities-some-allowed-multi-containers-some-labels.yml
+++ b/auditors/capabilities/fixtures/capabilities-some-allowed-multi-containers-some-labels.yml
@@ -11,8 +11,8 @@ spec:
     metadata:
       labels:
         name: deployment
-        container.audit.kubernetes.io/container1.allow-capability-chown: "SomeReason"
-        container.audit.kubernetes.io/container1.allow-capability-sys-time: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-capability-chown: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
         - name: container1

--- a/auditors/capabilities/fixtures/capabilities-some-allowed.yml
+++ b/auditors/capabilities/fixtures/capabilities-some-allowed.yml
@@ -11,8 +11,8 @@ spec:
     metadata:
       labels:
         name: deployment
-        audit.kubernetes.io/pod.allow-capability-chown: "SomeReason"
-        audit.kubernetes.io/pod.allow-capability-sys-time: "SomeReason"
+        audit.kubeaudit.io/pod.allow-capability-chown: "SomeReason"
+        audit.kubeaudit.io/pod.allow-capability-sys-time: "SomeReason"
     spec:
       containers:
         - name: container

--- a/auditors/hostns/fixtures/host-ipc-true-allowed.yml
+++ b/auditors/hostns/fixtures/host-ipc-true-allowed.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   namespace: host-ipc-true-allowed
   labels:
-    audit.kubernetes.io/pod.allow-namespace-host-IPC: "SomeReason"
+    audit.kubeaudit.io/pod.allow-namespace-host-IPC: "SomeReason"
 spec:
   hostIPC: true
   containers:

--- a/auditors/hostns/fixtures/host-network-true-allowed.yml
+++ b/auditors/hostns/fixtures/host-network-true-allowed.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   namespace: host-network-true-allowed
   labels:
-    audit.kubernetes.io/pod.allow-namespace-host-network: "SomeReason"
+    audit.kubeaudit.io/pod.allow-namespace-host-network: "SomeReason"
 spec:
   hostNetwork: true
   containers:

--- a/auditors/hostns/fixtures/host-pid-true-allowed.yml
+++ b/auditors/hostns/fixtures/host-pid-true-allowed.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   namespace: host-pid-true-allowed
   labels:
-    audit.kubernetes.io/pod.allow-namespace-host-PID: "SomeReason"
+    audit.kubeaudit.io/pod.allow-namespace-host-PID: "SomeReason"
 spec:
   hostPID: true
   containers:

--- a/auditors/hostns/fixtures/namespaces-all-true-allowed.yml
+++ b/auditors/hostns/fixtures/namespaces-all-true-allowed.yml
@@ -4,9 +4,9 @@ metadata:
   name: pod
   namespace: namespaces-all-true-allowed
   labels:
-    audit.kubernetes.io/pod.allow-namespace-host-network: "SomeReason"
-    audit.kubernetes.io/pod.allow-namespace-host-IPC: "SomeReason"
-    audit.kubernetes.io/pod.allow-namespace-host-PID: "SomeReason"
+    audit.kubeaudit.io/pod.allow-namespace-host-network: "SomeReason"
+    audit.kubeaudit.io/pod.allow-namespace-host-IPC: "SomeReason"
+    audit.kubeaudit.io/pod.allow-namespace-host-PID: "SomeReason"
 spec:
   hostPID: true
   hostIPC: true

--- a/auditors/hostns/fixtures/namespaces-redundant-override.yml
+++ b/auditors/hostns/fixtures/namespaces-redundant-override.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   namespace: namespaces-redundant-override
   labels:
-    audit.kubernetes.io/pod.allow-namespace-host-network: "SomeReason"
+    audit.kubeaudit.io/pod.allow-namespace-host-network: "SomeReason"
 spec:
   hostNetwork: false
   containers:

--- a/auditors/mounts/fixtures/proc-mounted-allowed-multi-containers-multi-labels.yml
+++ b/auditors/mounts/fixtures/proc-mounted-allowed-multi-containers-multi-labels.yml
@@ -4,8 +4,8 @@ metadata:
   name: pod
   labels:
     name: pod
-    container.audit.kubernetes.io/container1.allow-host-path-mount-proc-volume: "SomeReason"
-    container.audit.kubernetes.io/container2.allow-host-path-mount-proc-volume: "SomeReason"
+    container.audit.kubeaudit.io/container1.allow-host-path-mount-proc-volume: "SomeReason"
+    container.audit.kubeaudit.io/container2.allow-host-path-mount-proc-volume: "SomeReason"
   namespace: proc-mounted-allowed-multi-containers-multi-labels
 spec:
   containers:

--- a/auditors/mounts/fixtures/proc-mounted-allowed-multi-containers-single-label.yml
+++ b/auditors/mounts/fixtures/proc-mounted-allowed-multi-containers-single-label.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   labels:
     name: pod
-    container.audit.kubernetes.io/container1.allow-host-path-mount-proc-volume: "SomeReason"
+    container.audit.kubeaudit.io/container1.allow-host-path-mount-proc-volume: "SomeReason"
   namespace: proc-mounted-allowed-multi-containers-single-label
 spec:
   containers:

--- a/auditors/mounts/fixtures/proc-mounted-allowed.yml
+++ b/auditors/mounts/fixtures/proc-mounted-allowed.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   labels:
     name: pod
-    audit.kubernetes.io/pod.allow-host-path-mount-proc-volume: "SomeReason"
+    audit.kubeaudit.io/pod.allow-host-path-mount-proc-volume: "SomeReason"
   namespace: proc-mounted-allowed
 spec:
   containers:

--- a/auditors/netpols/fixtures/namespace-missing-default-deny-egress-netpol-allowed.yml
+++ b/auditors/netpols/fixtures/namespace-missing-default-deny-egress-netpol-allowed.yml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: namespace-missing-default-deny-egress-netpol-allowed
   labels:
-    audit.kubernetes.io/namespace.allow-non-default-deny-egress-network-policy: "SomeReason"
+    audit.kubeaudit.io/namespace.allow-non-default-deny-egress-network-policy: "SomeReason"
 ---
 # https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic
 apiVersion: networking.k8s.io/v1

--- a/auditors/netpols/fixtures/namespace-missing-default-deny-ingress-netpol-allowed.yml
+++ b/auditors/netpols/fixtures/namespace-missing-default-deny-ingress-netpol-allowed.yml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: namespace-missing-default-deny-ingress-netpol-allowed
   labels:
-    audit.kubernetes.io/namespace.allow-non-default-deny-ingress-network-policy: "SomeReason"
+    audit.kubeaudit.io/namespace.allow-non-default-deny-ingress-network-policy: "SomeReason"
 ---
 # https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-traffic
 apiVersion: networking.k8s.io/v1

--- a/auditors/netpols/fixtures/namespace-missing-default-deny-netpol-allowed.yml
+++ b/auditors/netpols/fixtures/namespace-missing-default-deny-netpol-allowed.yml
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
   name: namespace-missing-default-deny-netpol-allowed
   labels:
-    audit.kubernetes.io/namespace.allow-non-default-deny-egress-network-policy: "SomeReason"
-    audit.kubernetes.io/namespace.allow-non-default-deny-ingress-network-policy: "SomeReason"
+    audit.kubeaudit.io/namespace.allow-non-default-deny-egress-network-policy: "SomeReason"
+    audit.kubeaudit.io/namespace.allow-non-default-deny-ingress-network-policy: "SomeReason"
 ---
 # https://github.com/ahmetb/kubernetes-network-policy-recipes/blob/master/07-allow-traffic-from-some-pods-in-another-namespace.md
 kind: NetworkPolicy

--- a/auditors/nonroot/fixtures/run-as-non-root-false-allowed.yml
+++ b/auditors/nonroot/fixtures/run-as-non-root-false-allowed.yml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         name: deployment
-        audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
+        audit.kubeaudit.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
     spec:
       containers:
         - name: container

--- a/auditors/nonroot/fixtures/run-as-non-root-psc-false-allowed-multi-containers-multi-labels.yml
+++ b/auditors/nonroot/fixtures/run-as-non-root-psc-false-allowed-multi-containers-multi-labels.yml
@@ -4,8 +4,8 @@ metadata:
   name: pod
   labels:
     name: pod
-    container.audit.kubernetes.io/container1.allow-run-as-root: "SuperuserPrivilegesNeeded"
-    container.audit.kubernetes.io/container2.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    container.audit.kubeaudit.io/container1.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    container.audit.kubeaudit.io/container2.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: run-as-non-root-psc-false-allowed-multi-containers-multi-labels
 spec:
   securityContext:

--- a/auditors/nonroot/fixtures/run-as-non-root-psc-false-allowed-multi-containers-single-label.yml
+++ b/auditors/nonroot/fixtures/run-as-non-root-psc-false-allowed-multi-containers-single-label.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   labels:
     name: pod
-    container.audit.kubernetes.io/container1.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    container.audit.kubeaudit.io/container1.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: run-as-non-root-psc-false-allowed-multi-containers-single-label
 spec:
   securityContext:

--- a/auditors/nonroot/fixtures/run-as-non-root-psc-false-allowed.yml
+++ b/auditors/nonroot/fixtures/run-as-non-root-psc-false-allowed.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   labels:
     name: pod
-    audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    audit.kubeaudit.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: run-as-non-root-psc-false-allowed
 spec:
   securityContext:

--- a/auditors/nonroot/fixtures/run-as-non-root-redundant-override-container.yml
+++ b/auditors/nonroot/fixtures/run-as-non-root-redundant-override-container.yml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         name: deployment
-        audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
+        audit.kubeaudit.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
     spec:
       containers:
         - name: container

--- a/auditors/nonroot/fixtures/run-as-non-root-redundant-override-pod.yml
+++ b/auditors/nonroot/fixtures/run-as-non-root-redundant-override-pod.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   labels:
     name: pod
-    audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    audit.kubeaudit.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: run-as-non-root-redundant-override-pod
 spec:
   securityContext:

--- a/auditors/nonroot/fixtures/run-as-user-0-allowed.yml
+++ b/auditors/nonroot/fixtures/run-as-user-0-allowed.yml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         name: deployment
-        audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
+        audit.kubeaudit.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
     spec:
       containers:
         - name: container

--- a/auditors/nonroot/fixtures/run-as-user-psc-0-allowed-multi-containers-multi-labels.yml
+++ b/auditors/nonroot/fixtures/run-as-user-psc-0-allowed-multi-containers-multi-labels.yml
@@ -4,8 +4,8 @@ metadata:
   name: pod
   labels:
     name: pod
-    container.audit.kubernetes.io/container1.allow-run-as-root: "SuperuserPrivilegesNeeded"
-    container.audit.kubernetes.io/container2.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    container.audit.kubeaudit.io/container1.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    container.audit.kubeaudit.io/container2.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: run-as-user-psc-0-allowed-multi-containers-multi-labels
 spec:
   securityContext:

--- a/auditors/nonroot/fixtures/run-as-user-psc-0-allowed-multi-containers-single-label.yml
+++ b/auditors/nonroot/fixtures/run-as-user-psc-0-allowed-multi-containers-single-label.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   labels:
     name: pod
-    container.audit.kubernetes.io/container2.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    container.audit.kubeaudit.io/container2.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: run-as-user-psc-0-allowed-multi-containers-single-label
 spec:
   securityContext:

--- a/auditors/nonroot/fixtures/run-as-user-psc-0-allowed.yml
+++ b/auditors/nonroot/fixtures/run-as-user-psc-0-allowed.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   labels:
     name: pod
-    audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    audit.kubeaudit.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: run-as-user-psc-0-allowed
 spec:
   securityContext:

--- a/auditors/nonroot/fixtures/run-as-user-redundant-override-container.yml
+++ b/auditors/nonroot/fixtures/run-as-user-redundant-override-container.yml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         name: deployment
-        audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
+        audit.kubeaudit.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
     spec:
       containers:
         - name: container

--- a/auditors/nonroot/fixtures/run-as-user-redundant-override-pod.yml
+++ b/auditors/nonroot/fixtures/run-as-user-redundant-override-pod.yml
@@ -4,7 +4,7 @@ metadata:
   name: pod
   labels:
     name: pod
-    audit.kubernetes.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
+    audit.kubeaudit.io/pod.allow-run-as-root: "SuperuserPrivilegesNeeded"
   namespace: run-as-user-redundant-override-pod
 spec:
   securityContext:

--- a/auditors/privesc/fixtures/allow-privilege-escalation-redundant-override.yml
+++ b/auditors/privesc/fixtures/allow-privilege-escalation-redundant-override.yml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         name: statefulset
-        audit.kubernetes.io/pod.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
+        audit.kubeaudit.io/pod.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
         - name: container

--- a/auditors/privesc/fixtures/allow-privilege-escalation-true-allowed.yml
+++ b/auditors/privesc/fixtures/allow-privilege-escalation-true-allowed.yml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         name: statefulset
-        audit.kubernetes.io/pod.allow-privilege-escalation: ""
+        audit.kubeaudit.io/pod.allow-privilege-escalation: ""
     spec:
       containers:
         - name: container

--- a/auditors/privesc/fixtures/allow-privilege-escalation-true-multi-allowed-multi-containers.yml
+++ b/auditors/privesc/fixtures/allow-privilege-escalation-true-multi-allowed-multi-containers.yml
@@ -12,8 +12,8 @@ spec:
     metadata:
       labels:
         name: statefulset
-        container.audit.kubernetes.io/container1.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
-        container.audit.kubernetes.io/container2.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
+        container.audit.kubeaudit.io/container1.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
+        container.audit.kubeaudit.io/container2.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
         - name: container1

--- a/auditors/privesc/fixtures/allow-privilege-escalation-true-single-allowed-multi-containers.yml
+++ b/auditors/privesc/fixtures/allow-privilege-escalation-true-single-allowed-multi-containers.yml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         name: statefulset
-        container.audit.kubernetes.io/container2.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
+        container.audit.kubeaudit.io/container2.allow-privilege-escalation: "SuperuserPrivilegesNeeded"
     spec:
       containers:
         - name: container1

--- a/auditors/privileged/fixtures/privileged-redundant-override.yml
+++ b/auditors/privileged/fixtures/privileged-redundant-override.yml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         name: daemonset
-        audit.kubernetes.io/pod.allow-privileged: "SomeReason"
+        audit.kubeaudit.io/pod.allow-privileged: "SomeReason"
     spec:
       containers:
         - name: container

--- a/auditors/privileged/fixtures/privileged-true-allowed-multi-containers-multi-labels.yml
+++ b/auditors/privileged/fixtures/privileged-true-allowed-multi-containers-multi-labels.yml
@@ -12,8 +12,8 @@ spec:
     metadata:
       labels:
         name: daemonset
-        container.audit.kubernetes.io/container1.allow-privileged: "SomeReason"
-        container.audit.kubernetes.io/container2.allow-privileged: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-privileged: "SomeReason"
+        container.audit.kubeaudit.io/container2.allow-privileged: "SomeReason"
     spec:
       containers:
         - name: container1

--- a/auditors/privileged/fixtures/privileged-true-allowed-multi-containers-single-label.yml
+++ b/auditors/privileged/fixtures/privileged-true-allowed-multi-containers-single-label.yml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         name: daemonset
-        container.audit.kubernetes.io/container2.allow-privileged: "SomeReason"
+        container.audit.kubeaudit.io/container2.allow-privileged: "SomeReason"
     spec:
       containers:
         - name: container1

--- a/auditors/privileged/fixtures/privileged-true-allowed.yml
+++ b/auditors/privileged/fixtures/privileged-true-allowed.yml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         name: daemonset
-        audit.kubernetes.io/pod.allow-privileged: "SomeReason"
+        audit.kubeaudit.io/pod.allow-privileged: "SomeReason"
     spec:
       containers:
         - name: container

--- a/auditors/rootfs/fixtures/read-only-root-filesystem-false-allowed-multi-labels.yml
+++ b/auditors/rootfs/fixtures/read-only-root-filesystem-false-allowed-multi-labels.yml
@@ -13,8 +13,8 @@ spec:
     metadata:
       labels:
         name: statefulset
-        container.audit.kubernetes.io/container1.allow-read-only-root-filesystem-false: "SomeReason"
-        container.audit.kubernetes.io/container2.allow-read-only-root-filesystem-false: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-read-only-root-filesystem-false: "SomeReason"
+        container.audit.kubeaudit.io/container2.allow-read-only-root-filesystem-false: "SomeReason"
     spec:
       containers:
         - name: container1

--- a/auditors/rootfs/fixtures/read-only-root-filesystem-false-allowed-single-label.yml
+++ b/auditors/rootfs/fixtures/read-only-root-filesystem-false-allowed-single-label.yml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         name: statefulset
-        container.audit.kubernetes.io/container1.allow-read-only-root-filesystem-false: "SomeReason"
+        container.audit.kubeaudit.io/container1.allow-read-only-root-filesystem-false: "SomeReason"
     spec:
       containers:
         - name: container1

--- a/auditors/rootfs/fixtures/read-only-root-filesystem-false-allowed.yml
+++ b/auditors/rootfs/fixtures/read-only-root-filesystem-false-allowed.yml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         name: statefulset
-        audit.kubernetes.io/pod.allow-read-only-root-filesystem-false: "SomeReason"
+        audit.kubeaudit.io/pod.allow-read-only-root-filesystem-false: "SomeReason"
     spec:
       containers:
         - name: container

--- a/auditors/rootfs/fixtures/read-only-root-filesystem-redundant-override.yml
+++ b/auditors/rootfs/fixtures/read-only-root-filesystem-redundant-override.yml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         name: statefulset
-        audit.kubernetes.io/pod.allow-read-only-root-filesystem-false: "SomeReason"
+        audit.kubeaudit.io/pod.allow-read-only-root-filesystem-false: "SomeReason"
     spec:
       containers:
         - name: container

--- a/docs/auditors/apparmor.md
+++ b/docs/auditors/apparmor.md
@@ -86,7 +86,7 @@ Override identifier for the `unconfined` apparmor profile value: `allow-disabled
 
 Container overrides have the form:
 ```yaml
-container.audit.kubernetes.io/[container name].allow-disabled-apparmor: "SomeReason"
+container.audit.kubeaudit.io/[container name].allow-disabled-apparmor: "SomeReason"
 ```
 
 Example of resource with the `unconfined` apparmor profile overridden for a specific container:
@@ -99,7 +99,7 @@ spec:
       annotations:
         container.apparmor.security.beta.kubernetes.io/myContainer: unconfined
       labels:
-        container.audit.kubernetes.io/myContainer.allow-disabled-apparmor: "SomeReason"
+        container.audit.kubeaudit.io/myContainer.allow-disabled-apparmor: "SomeReason"
     spec:
       containers:
       - name: myContainer

--- a/docs/auditors/asat.md
+++ b/docs/auditors/asat.md
@@ -1,7 +1,7 @@
 # automountServiceAccountToken Auditor (asat)
 
 Finds containers that meet either of the following conditions:
-1. The deprecated `serviceAccount` field is used 
+1. The deprecated `serviceAccount` field is used
 1. The default service account is automatically mounted
 
 ## General Usage
@@ -95,7 +95,7 @@ Override identifier: `allow-automount-service-account-token`
 
 Only pod overrides are supported:
 ```yaml
-audit.kubernetes.io/pod.allow-automount-service-account-token: ""
+audit.kubeaudit.io/pod.allow-automount-service-account-token: ""
 ```
 
 Example of a resource with `asat` results overridden:
@@ -106,7 +106,7 @@ spec:
   template:
     metadata:
       labels:
-        audit.kubernetes.io/pod.allow-automount-service-account-token: ""
+        audit.kubeaudit.io/pod.allow-automount-service-account-token: ""
     spec:
       automountServiceAccountToken: true
       containers:

--- a/docs/auditors/capabilities.md
+++ b/docs/auditors/capabilities.md
@@ -89,7 +89,7 @@ $ kubeaudit all --kconfig "config.yaml" -f "manifest.yaml"
 --------------------------------------------
 
 -- [error] CapabilityAdded
-   Message: Capability "CHOWN" added. It should be removed from the capability add list. If you need this capability, add an override label such as'container.audit.kubernetes.io/container1.allow-capability-chown: SomeReason'.
+   Message: Capability "CHOWN" added. It should be removed from the capability add list. If you need this capability, add an override label such as'container.audit.kubeaudit.io/container1.allow-capability-chown: SomeReason'.
    Metadata:
       Container: container1
 ```
@@ -126,7 +126,7 @@ Here we're only adding 3 capabilities to the add list to be ignored. Since we di
 --------------------------------------------
 
 -- [error] CapabilityAdded
-   Message: Capability "NET_ADMIN" added. It should be removed from the capability add list. If you need this capability, add an override label such as 'container.audit.kubernetes.io/container1.allow-capability-net-admin: SomeReason'.
+   Message: Capability "NET_ADMIN" added. It should be removed from the capability add list. If you need this capability, add an override label such as 'container.audit.kubeaudit.io/container1.allow-capability-net-admin: SomeReason'.
    Metadata:
       Container: container1
       Capabiliy: NET_ADMIN
@@ -193,13 +193,13 @@ For example, the override identifier for the `AUDIT_WRITE` capability would be `
 Container overrides have the form:
 
 ```yaml
-container.audit.kubernetes.io/[container name].[override identifier]: ''
+container.audit.kubeaudit.io/[container name].[override identifier]: ''
 ```
 
 Pod overrides have the form:
 
 ```yaml
-audit.kubernetes.io/pod.[override identifier]: ''
+audit.kubeaudit.io/pod.[override identifier]: ''
 ```
 
 Example of a resource with `AUDIT_WRITE` and `DAC_OVERRIDE` capabilities overridden for a specific container:
@@ -211,8 +211,8 @@ spec:
   template:
     metadata:
       labels:
-        container.audit.kubernetes.io/myContainer.allow-capability-audit-write: ''
-        container.audit.kubernetes.io/myContainer.allow-capability-dac-override: ''
+        container.audit.kubeaudit.io/myContainer.allow-capability-audit-write: ''
+        container.audit.kubeaudit.io/myContainer.allow-capability-dac-override: ''
     spec:
       containers:
         - name: myContainer
@@ -234,8 +234,8 @@ spec:
   template:
     metadata:
       labels:
-        audit.kubernetes.io/pod.allow-capability-audit-write: ''
-        audit.kubernetes.io/pod.allow-capability-dac-override: ''
+        audit.kubeaudit.io/pod.allow-capability-audit-write: ''
+        audit.kubeaudit.io/pod.allow-capability-dac-override: ''
     spec:
       containers:
         - name: myContainer

--- a/docs/auditors/hostns.md
+++ b/docs/auditors/hostns.md
@@ -74,12 +74,12 @@ Each host namespace field can be individually overridden using their respective 
 
 Container overrides have the form:
 ```yaml
-container.audit.kubernetes.io/[container name].[override identifier]: ""
+container.audit.kubeaudit.io/[container name].[override identifier]: ""
 ```
 
 Pod overrides have the form:
 ```yaml
-audit.kubernetes.io/pod.[override identifier]: ""
+audit.kubeaudit.io/pod.[override identifier]: ""
 ```
 
 Example of a resource with `HostPID` overridden for a specific container:
@@ -90,7 +90,7 @@ spec:
   template:
     metadata:
       labels:
-        container.audit.kubernetes.io/myContainer.allow-namespace-host-PID: ""
+        container.audit.kubeaudit.io/myContainer.allow-namespace-host-PID: ""
     spec:
       hostPID: true
       containers:
@@ -105,7 +105,7 @@ spec:
   template:
     metadata:
       labels:
-        audit.kubernetes.io/pod.allow-namespace-host-PID: ""
+        audit.kubeaudit.io/pod.allow-namespace-host-PID: ""
     spec:
       hostPID: true
       containers:

--- a/docs/auditors/mounts.md
+++ b/docs/auditors/mounts.md
@@ -233,7 +233,7 @@ spec:
   template: #PodTemplateSpec
     metadata:
       labels:
-        container.audit.kubernetes.io/container2.allow-host-path-mount-proc-volume: "SomeReason"
+        container.audit.kubeaudit.io/container2.allow-host-path-mount-proc-volume: "SomeReason"
     spec: #PodSpec
       containers:
         - name: container1
@@ -258,7 +258,7 @@ spec:
   template: #PodTemplateSpec
     metadata:
       labels:
-        audit.kubernetes.io/pod.allow-host-path-mount-proc-volume: "SomeReason"
+        audit.kubeaudit.io/pod.allow-host-path-mount-proc-volume: "SomeReason"
     spec: #PodSpec
       containers:
         - name: container1

--- a/docs/auditors/netpols.md
+++ b/docs/auditors/netpols.md
@@ -59,7 +59,7 @@ First, see the [Introduction to Override Errors](/README.md#override-errors).
 
 The `netpols` auditor uses a unique override label type not used by any other auditor because the label applies to a namespace (rather than a container or pod):
 ```
-audit.kubernetes.io/namespace.[override identifier]: ""
+audit.kubeaudit.io/namespace.[override identifier]: ""
 ```
 
 Deny-all ingress and egress network policies can be individually overridden using their respective override identifiers:
@@ -76,7 +76,7 @@ kind: Namespace
 metadata:
   name: "default"
   labels:
-    audit.kubernetes.io/namespace.allow-non-default-deny-ingress-network-policy: ""
+    audit.kubeaudit.io/namespace.allow-non-default-deny-ingress-network-policy: ""
 ```
 
 ### Override Example
@@ -118,14 +118,14 @@ The `netpols` auditor will produce an error because there is no `deny-all` Netwo
       Namespace: my-namespace
 ```
 
-This error can be overridden by adding the `audit.kubernetes.io/namespace.allow-non-default-deny-ingress-network-policy: ""` label to the corresponding Namespace resource:
+This error can be overridden by adding the `audit.kubeaudit.io/namespace.allow-non-default-deny-ingress-network-policy: ""` label to the corresponding Namespace resource:
 ```yaml
 apiVersion: v1
 kind: Namespace
 metadata:
   name: "my-namespace"
   labels:
-    audit.kubernetes.io/namespace.allow-non-default-deny-ingress-network-policy: ""
+    audit.kubeaudit.io/namespace.allow-non-default-deny-ingress-network-policy: ""
 ```
 
 The auditor will now produce a warning instead of an error:

--- a/docs/auditors/nonroot.md
+++ b/docs/auditors/nonroot.md
@@ -52,7 +52,7 @@ spec:
       - name: myContainer
 ```
 
-Alternatively it's possible to enforce non-root containers by setting `runAsUser` to a non-root UID (>0) in either the PodSecurityContext or container SecurityContext. Conversely, if `runAsUser` is set to `0` in either the PodSecurityContext or container SecurityContext then the container will always run as root and so the audit will fail. 
+Alternatively it's possible to enforce non-root containers by setting `runAsUser` to a non-root UID (>0) in either the PodSecurityContext or container SecurityContext. Conversely, if `runAsUser` is set to `0` in either the PodSecurityContext or container SecurityContext then the container will always run as root and so the audit will fail.
 
 If `runAsUser` is set to a non-root UID (either in PodSecurityContext or container SecurityContext) it won't matter if `runAsNonRoot` is set to `false` or `nil` and so the audit will always pass.
 
@@ -81,12 +81,12 @@ Override identifer: `allow-run-as-root`
 
 Container overrides have the form:
 ```yaml
-container.audit.kubernetes.io/[container name].allow-run-as-root: ""
+container.audit.kubeaudit.io/[container name].allow-run-as-root: ""
 ```
 
 Pod overrides have the form:
 ```yaml
-audit.kubernetes.io/pod.allow-run-as-root: ""
+audit.kubeaudit.io/pod.allow-run-as-root: ""
 ```
 
 Example of resource with `nonroot` overridden for a specific container:
@@ -97,7 +97,7 @@ spec:
   template: #PodTemplateSpec
     metadata:
       labels:
-        container.audit.kubernetes.io/myContainer.allow-run-as-root: ""
+        container.audit.kubeaudit.io/myContainer.allow-run-as-root: ""
     spec: #PodSpec
       securityContext: #PodSecurityContext
         runAsNonRoot: true
@@ -116,7 +116,7 @@ spec:
   template: #PodTemplateSpec
     metadata:
       labels:
-        audit.kubernetes.io/pod.allow-run-as-root: ""
+        audit.kubeaudit.io/pod.allow-run-as-root: ""
     spec: #PodSpec
       securityContext: #PodSecurityContext
         runAsNonRoot: true
@@ -137,7 +137,7 @@ spec:
   template: #PodTemplateSpec
     metadata:
       labels:
-        container.audit.kubernetes.io/myContainer.allow-run-as-root: ""
+        container.audit.kubeaudit.io/myContainer.allow-run-as-root: ""
     spec: #PodSpec
       securityContext: #PodSecurityContext
         runAsUser: 1000

--- a/docs/auditors/privesc.md
+++ b/docs/auditors/privesc.md
@@ -58,12 +58,12 @@ Override identifier: `allow-privilege-escalation`
 
 Container overrides have the form:
 ```yaml
-container.audit.kubernetes.io/[container name].allow-privilege-escalation: ""
+container.audit.kubeaudit.io/[container name].allow-privilege-escalation: ""
 ```
 
 Pod overrides have the form:
 ```yaml
-audit.kubernetes.io/pod.allow-privilege-escalation: ""
+audit.kubeaudit.io/pod.allow-privilege-escalation: ""
 ```
 
 Example of resource with `privesc` overridden for a specific container:
@@ -74,7 +74,7 @@ spec:
   template:
     metadata:
       labels:
-        container.audit.kubernetes.io/myContainer.allow-privilege-escalation: ""
+        container.audit.kubeaudit.io/myContainer.allow-privilege-escalation: ""
     spec:
       containers:
       - name: myContainer
@@ -90,7 +90,7 @@ spec:
   template:
     metadata:
       labels:
-        audit.kubernetes.io/pod.allow-privilege-escalation: ""
+        audit.kubeaudit.io/pod.allow-privilege-escalation: ""
     spec:
       containers:
       - name: myContainer

--- a/docs/auditors/privileged.md
+++ b/docs/auditors/privileged.md
@@ -59,12 +59,12 @@ Override identifier: `allow-privileged`
 
 Container overrides have the form:
 ```yaml
-container.audit.kubernetes.io/[container name].allow-privileged: ""
+container.audit.kubeaudit.io/[container name].allow-privileged: ""
 ```
 
 Pod overrides have the form:
 ```yaml
-audit.kubernetes.io/pod.allow-privileged: ""
+audit.kubeaudit.io/pod.allow-privileged: ""
 ```
 
 Example of resource with `privileged` overridden for a specific container:
@@ -75,7 +75,7 @@ spec:
   template:
     metadata:
       labels:
-        container.audit.kubernetes.io/myContainer.allow-privilege-escalation: ""
+        container.audit.kubeaudit.io/myContainer.allow-privilege-escalation: ""
     spec:
       containers:
       - name: myContainer
@@ -91,7 +91,7 @@ spec:
   template:
     metadata:
       labels:
-        audit.kubernetes.io/pod.allow-privileged: ""
+        audit.kubeaudit.io/pod.allow-privileged: ""
     spec:
       containers:
       - name: myContainer

--- a/docs/auditors/rootfs.md
+++ b/docs/auditors/rootfs.md
@@ -60,12 +60,12 @@ Override identifier: `allow-read-only-root-filesystem-false`
 
 Container overrides have the form:
 ```yaml
-container.audit.kubernetes.io/[container name].allow-read-only-root-filesystem-false: ""
+container.audit.kubeaudit.io/[container name].allow-read-only-root-filesystem-false: ""
 ```
 
 Pod overrides have the form:
 ```yaml
-audit.kubernetes.io/pod.allow-read-only-root-filesystem-false: ""
+audit.kubeaudit.io/pod.allow-read-only-root-filesystem-false: ""
 ```
 
 Example of resource with `rootfs` overridden for a specific container:
@@ -76,7 +76,7 @@ spec:
   template:
     metadata:
       labels:
-        container.audit.kubernetes.io/myContainer.allow-read-only-root-filesystem-false: ""
+        container.audit.kubeaudit.io/myContainer.allow-read-only-root-filesystem-false: ""
     spec:
       containers:
       - name: myContainer
@@ -92,7 +92,7 @@ spec:
   template:
     metadata:
       labels:
-        audit.kubernetes.io/pod.allow-read-only-root-filesystem-false: ""
+        audit.kubeaudit.io/pod.allow-read-only-root-filesystem-false: ""
     spec:
       containers:
       - name: myContainer

--- a/pkg/override/override.go
+++ b/pkg/override/override.go
@@ -9,11 +9,11 @@ import (
 
 const (
 	// ContainerOverrideLabelPrefix is used to disable an auditor for a specific container
-	ContainerOverrideLabelPrefix = "container.audit.kubernetes.io/"
+	ContainerOverrideLabelPrefix = "container.audit.kubeaudit.io/"
 	// PodOverrideLabelPrefix is used to disable an auditor for a specific pod
-	PodOverrideLabelPrefix = "audit.kubernetes.io/pod."
+	PodOverrideLabelPrefix = "audit.kubeaudit.io/pod."
 	// NamespaceOverrideLabelPrefix is used to disable an auditor for a specific namespace resource
-	NamespaceOverrideLabelPrefix = "audit.kubernetes.io/namespace."
+	NamespaceOverrideLabelPrefix = "audit.kubeaudit.io/namespace."
 )
 
 // GetOverriddenResultName takes an audit result name and modifies it to indicate that the security issue was
@@ -69,7 +69,8 @@ func ApplyOverride(auditResult *kubeaudit.AuditResult, auditorName, containerNam
 // value of the label which is meant to represent the reason for overriding the auditor
 //
 // Container override labels disable the auditor for that specific container and have the following format:
-// 		container.audit.kubernetes.io/[container name].[auditor override label]
+//
+//	container.audit.kubeaudit.io/[container name].[auditor override label]
 //
 // If there is no container override label, it calls GetResourceOverrideReason()
 func GetContainerOverrideReason(containerName string, resource k8s.Resource, overrideLabel string) (hasOverride bool, reason string) {
@@ -88,9 +89,12 @@ func GetContainerOverrideReason(containerName string, resource k8s.Resource, ove
 // label which is meant to represent the reason for overriding the auditor
 //
 // Pod override labels disable the auditor for the pod and all containers within the pod and have the following format:
-// 		audit.kubernetes.io/pod.[auditor override label]
+//
+//	audit.kubeaudit.io/pod.[auditor override label]
+//
 // Namespace override labels disable the auditor for the namespace resource and have the following format:
-// 		audit.kubernetes.io/namespace.[auditor override label]
+//
+//	audit.kubeaudit.io/namespace.[auditor override label]
 func GetResourceOverrideReason(resource k8s.Resource, auditorOverrideLabel string) (hasOverride bool, reason string) {
 	labelFuncs := []func(overrideLabel string) string{
 		GetPodOverrideLabel,


### PR DESCRIPTION
##### Description

This PR addresses feedback from the kubernetes community on using [unregistered annotations](https://github.com/Shopify/kubeaudit/issues/457).

We have purchased a domain (`kubeaudit.io`) as suggested for our own purpose: override labels.

This is backwards compatible. The override logic is implemented in a way that given`container.audit.kubeaudit.io/container.allow-disabled-apparmor: "SomeReason"` for example, the part that makes the decision on overriding or not is `container.allow-disabled-apparmor: "SomeReason"` not what prefixes it.

So it seems safe to just change the annotations and announce these changes once we make the next release

Thoughts?

Fixes # (issue)

https://github.com/Shopify/kubeaudit/issues/457
##### Type of change

<!-- Please delete options that are not relevant. --->
- [] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

##### Checklist:

- [ ] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
