### PR TITLE
fix unmarshal errors not found for known k8s schema

### DIFF
--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@ package kubeaudit
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/Shopify/kubeaudit/internal/k8sinternal"
@@ -29,6 +30,9 @@ func getResourcesFromManifest(data []byte) ([]KubeResource, error) {
 
 	for _, b := range bufSlice {
 		obj, err := k8sinternal.DecodeResource(b)
+		if _, ok := err.(*json.UnmarshalTypeError); ok {
+			return nil, err
+		}
 		if err == nil && obj != nil {
 			source := &kubeResource{
 				object: obj,


### PR DESCRIPTION
<!-- Please erase any parts of this template not applicable to your Pull Request. -->

<!-- All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes) -->

##### Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #523 (known schema not raising errors when incompatible with k8s resource definitions)

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Tested using the example provided in #523. Prior to this change there was no error; now, known resources (e.g. Deployments) raise an error when the unmarshaling goes wrong (like unquoted labels) and clearly shows that there is a misconfiguration in the manifest.

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
