### PR TITLE
capture exit code for sarif

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -89,6 +89,10 @@ func runAudit(auditable ...kubeaudit.Auditable) func(cmd *cobra.Command, args []
 				log.WithError(err).Fatal("Error generating the SARIF output")
 			}
 			sarifReport.PrettyWrite(os.Stdout)
+
+			if report.HasErrors() {
+				os.Exit(rootConfig.exitCode)
+			}
 			return
 		case "json":
 			printOptions = append(printOptions, kubeaudit.WithFormatter(&log.JSONFormatter{}))


### PR DESCRIPTION
##### Description

When running `kubeaudit` on the cli, we generally yield an exit code other than 0 if the report contains errors. 

However, when we run it with the sarif format, we get 0 even when we have errors. This happens, because we're returning
[here ](https://github.com/Shopify/kubeaudit/blob/644b42c9144e19264037ac9f6e37013938da0631/cmd/commands/root.go#L96)to avoid printing extra info to the console. This means [we never reach this line](https://github.com/Shopify/kubeaudit/blob/644b42c9144e19264037ac9f6e37013938da0631/cmd/commands/root.go#L105).

Fixes #575

##### Type of change

<!-- Please delete options that are not relevant. --->
- [x] Bug fix :bug:
- [ ] New feature :sparkles:
- [ ] This change requires a documentation update :book:
- [ ] Breaking changes :warning:
##### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A
1. use one of the manifest files in the repo to test. Example: `auditors/privileged/fixtures/privileged-nil.yml`

2. `go run ./cmd/main.go all -f auditors/privileged/fixtures/privileged-nil.yml --format=sarif`

3. when you run `echo $?` you should see `2`

##### Checklist:

- [x] I have :tophat: my changes (A 🎩 specifically includes pulling down changes, setting them up, and manually testing the changed features and potential side effects to make sure nothing is broken)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The test coverage did not decrease
- [x] I have signed the appropriate [Contributor License Agreement](https://cla.shopify.com/)
